### PR TITLE
fixed bug when dir is called on Dict object

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -56,6 +56,13 @@ class Dict(dict):
 
     def __setitem__(self, name, value):
         """
+        Calling the dir() method on this using python 2.7 adds "__members__" and "__methods__"
+        to the dictionary
+        """
+        if name == "__members__" or name == "__methods__":
+            return
+
+        """
         This is called when trying to set a value of the Dict using [].
         E.g. some_instance_of_Dict['b'] = val. If 'val
 


### PR DESCRIPTION
fixes bug #19 
The bug only appeared in 2.7 from what I can tell.
Not very familiar with python , but I assume no one would manually set the names **members** or **methods** anyway.
