### PR TITLE
Implements __dir__() for Dict, Fixes issue #19

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -86,6 +86,17 @@ class Dict(dict):
         """
         self.__delitem__(name)
 
+    def __dir__(self):
+        """
+        Is invoked on a Dict instance causes __getitem__() to get invoked
+        which in this module will trigger the creation of the following
+        properties: `__members__` and `__methods__`
+
+        To avoid these keys from being added, we simply return an explicit
+        call to dir for the Dict object
+        """
+        return dir(Dict)
+
     def _ipython_display_(self):
         print(str(self))
 

--- a/test_addict.py
+++ b/test_addict.py
@@ -208,3 +208,15 @@ class Tests(unittest.TestCase):
         self.assertRaises(AttributeError, set_items)
         self.assertDictEqual(prop, {})
 
+    def test_dir(self):
+        prop = Dict({'a': 1})
+        dir_prop = dir(prop)
+        self.assertEqual(dir_prop, dir(Dict))
+        self.assertTrue('__methods__' not in dir_prop)
+        self.assertTrue('__members__' not in dir_prop)
+
+    def test_dir_with_members(self):
+        prop = Dict({'__members__': 1})
+        dir(prop)
+        self.assertTrue('__members__' in prop.keys())
+


### PR DESCRIPTION
Implements `__dir__` for the Dict class. This avoids the default implementation of `dir()` to get called which checks to see if the object `hasitem('__members__')` and `hasitem('__methods__')`. Obviously the addict `hasitem()` will invoke the `setitem()` since the key does not exist :)

Also adds some tests which validate the above.
