### PR TITLE
run tests using "python test_addict.py"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ But don't you worry, if you by mistake added some empty Dicts in your Dict, you 
 >>> addicted.prune()
 {'a': 2}
 ```
+
 ### Stuff to keep in mind
 Also, remember that ```int```s are not valid attribute names, so keys of the dict that are not strings must be set/get with the get-/setitem syntax
 ```Python
@@ -71,6 +72,7 @@ However feel free to mix the two syntaxes:
 >>> addicted.a.b['c'].d.e
 2
 ```
+
 ###Attributes like keys, items etc.
 addict will not let you override attributes that are native to ```dict```, so the following will not work
 ```Python
@@ -101,11 +103,21 @@ body.query.filtered.filter.term.created_by = 'Mats'
 third_party_module.search(query=body.to_dict())
 ```
 ###When is this **especially** useful? 
-
 This module rose from the entirely tiresome creation of elasticsearch queries in Python. Whenever you find yourself writing out dicts over multiple lines, just remember that you don't have to. Use *addict* instead.
 
 ###Perks
 As it is a ```dict```, it will serialize into JSON perfectly, and with the to_dict()-method you can feel safe shipping your addict anywhere.
+
+###Testing, Development and CI
+Pull requests and commits will be automatically run against TravisCI and coveralls. 
+
+The unit tests are implemented in the `test_addict.py` file and use the unittest python framework. Running the tests is rather simple:
+```sh
+python -m unittest -v test_addict
+
+# - or -
+python test_addict.py
+```
 
 ###Testimonials
 @spiritsack - *"Mother of God, this changes everything."*

--- a/test_addict.py
+++ b/test_addict.py
@@ -312,3 +312,11 @@ class Tests(unittest.TestCase):
         self.assertIsInstance(regular['a'], tuple)
         self.assertNotIsInstance(regular['a'][0], Dict)
 
+
+"""
+Allow for these test cases to be run from the command line
+via `python test_addict.py`
+"""
+if __name__ == '__main__':
+    all_tests = unittest.TestLoader().loadTestsFromTestCase(Tests)
+    unittest.TextTestRunner(verbosity=2).run(all_tests)


### PR DESCRIPTION
This allows developers to run unit tests using `python test_addict.py`. This is particularly useful when we have all our tests loaded into a single file like we do.

The other option is to run something like:
`python -m unittest -v test_addict`

Also added info to the readme on how other devs might go about running tests etc :)
