### PR TITLE
Added recursive update and copy methods

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -211,3 +211,14 @@ class Dict(dict):
                base[key] = value
        return base
 
+    def update(self, d):
+        """
+        Recursively merge d into self.
+
+        """
+        for k, v in d.iteritems():
+            if (k not in self) or (not isinstance(self[k], dict)) or (not isinstance(v, dict)):
+                setattr(self, k, v)
+            else:
+                getattr(self, k).update(v)
+        return d

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -211,6 +211,15 @@ class Dict(dict):
                base[key] = value
        return base
 
+    def copy(self):
+        """
+        Return a disconnected deep copy of self. Children of type Dict, list
+        and tuple are copied recursively while values that are instances of
+        other mutable objects are not copied.
+
+        """
+        return Dict(self.to_dict())
+
     def update(self, d):
         """
         Recursively merge d into self.

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -216,7 +216,7 @@ class Dict(dict):
         Recursively merge d into self.
 
         """
-        for k, v in d.iteritems():
+        for k, v in d.items():
             if (k not in self) or (not isinstance(self[k], dict)) or (not isinstance(v, dict)):
                 setattr(self, k, v)
             else:

--- a/test_addict.py
+++ b/test_addict.py
@@ -332,6 +332,33 @@ class Tests(unittest.TestCase):
 
         self.assertDictEqual(old, reference)
 
+    def test_copy(self):
+        class MyMutableObject(object):
+            def __init__(self):
+                self.attribute = None
+
+        foo = MyMutableObject()
+        foo.attribute = True
+
+        a = Dict()
+        a.child.immutable = 42
+        a.child.mutable = foo
+
+        b = a.copy()
+
+        # immutable object should not change
+        b.child.immutable = 21
+        self.assertEqual(a.child.immutable, 42)
+
+        # mutable object should change
+        b.child.mutable.attribute = False
+        self.assertEqual(a.child.mutable.attribute, b.child.mutable.attribute)
+
+        # changing child of b should not affect a
+        b.child = "new stuff"
+        self.assertTrue(isinstance(a.child, Dict))
+
+
 
 """
 Allow for these test cases to be run from the command line

--- a/test_addict.py
+++ b/test_addict.py
@@ -312,6 +312,26 @@ class Tests(unittest.TestCase):
         self.assertIsInstance(regular['a'], tuple)
         self.assertNotIsInstance(regular['a'][0], Dict)
 
+    def test_update(self):
+        old = Dict()
+        old.child.a = 'old a'
+        old.child.b = 'old b'
+        old.foo = 'no dict'
+
+        new = Dict()
+        new.child.b = 'new b'
+        new.child.c = 'new c'
+        new.foo.now_my_papa_is_a_dict = True
+
+        old.update(new)
+
+        reference = {
+                'foo': {'now_my_papa_is_a_dict': True},
+                'child': {'a': 'old a', 'c': 'new c', 'b': 'new b'}
+                }
+
+        self.assertDictEqual(old, reference)
+
 
 """
 Allow for these test cases to be run from the command line


### PR DESCRIPTION
Added support for recursively merging dict-like stuff into a Dict instance.

```python
old = Dict()
old.foo.a = 1
old.foo.b = 2
old.bar = 42

new = Dict()
new.foo.b = 3
new.foo.c = 'new kid on the block'
new.bar.asd = 42

old.update(new)

print old
```

… gives:

```
{'foo': {'a': 1, 'c': 'new kid on the block', 'b': 3}, 'bar': {'asd': 42}}
```