### PR TITLE
Include keys as attributes returned by __dir__()

### DIFF
--- a/test_addict.py
+++ b/test_addict.py
@@ -248,9 +248,16 @@ class Tests(unittest.TestCase):
         self.assertDictEqual(prop, {})
 
     def test_dir(self):
-        prop = Dict({'a': 1})
+        key = 'a'
+        prop = Dict({key: 1})
         dir_prop = dir(prop)
-        self.assertEqual(dir_prop, dir(Dict))
+
+        dir_dict = dir(Dict)
+        for d in dir_dict:
+            self.assertTrue(d in dir_prop, d)
+
+        self.assertTrue(key in dir_prop)
+
         self.assertTrue('__methods__' not in dir_prop)
         self.assertTrue('__members__' not in dir_prop)
 


### PR DESCRIPTION
Updates to __dir__ method to address issues with autocomplete on Dict keys.  See #45 for details.