### PR TITLE
Fixing test case names

### DIFF
--- a/test_addict.py
+++ b/test_addict.py
@@ -197,14 +197,14 @@ class Tests(unittest.TestCase):
         prop.prune()
         self.assertDictEqual(prop, {'b': 2})
 
-    def test_iter_reduce(self):
+    def test_iter_reduce_with_list(self):
         prop = Dict()
         prop.a = [Dict(), 1, 2]
         prop.a[0].b.c
         prop.prune()
         self.assertDictEqual(prop, {'a': [1, 2]})
 
-    def test_iter_reduce(self):
+    def test_iter_reduce_with_tuple(self):
         prop = Dict()
         prop.a = (Dict(), 1, 2)
         prop.a[0].b.c


### PR DESCRIPTION
There are two cases with the same name `test_iter_reduce`, so only the second one is always executed and the first one is dead code. So fixing the names of the test cases.