### PR TITLE
swaps dict for OrderedDict as base class

### DIFF
--- a/addict/__init__.py
+++ b/addict/__init__.py
@@ -1,4 +1,4 @@
-from .addict import Dict
+from .addict import Dict, OrderedDict
 
 
 __title__ = 'addict'
@@ -6,4 +6,4 @@ __version__ = '0.4.0'
 __author__ = 'Mats Julian Olsen'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2014 Mats Julian Olsen'
-__all__ = ['Dict']
+__all__ = ['Dict', 'OrderedDict']

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -1,253 +1,261 @@
 from inspect import isgenerator
 import re
 import copy
-from collections import OrderedDict
+from collections import OrderedDict as CollectionsOrderedDict
 
 
-class Dict(OrderedDict):
-    """
-    Dict is a subclass of dict, which allows you to get AND SET(!!)
-    items in the dict using the attribute syntax!
-
-    When you previously had to write:
-
-    my_dict = {'a': {'b': {'c': [1, 2, 3]}}}
-
-    you can now do the same simply by:
-
-    my_Dict = Dict()
-    my_Dict.a.b.c = [1, 2, 3]
-
-    Or for instance, if you'd like to add some additional stuff,
-    where you'd with the normal dict would write
-
-    my_dict['a']['b']['d'] = [4, 5, 6],
-
-    you may now do the AWESOME
-
-    my_Dict.a.b.d = [4, 5, 6]
-
-    instead. But hey, you can always use the same syntax as a regular dict,
-    however, this will not raise TypeErrors or AttributeErrors at any time
-    while you try to get an item. A lot like a defaultdict.
-
-    """
-
-    def __init__(self, *args, **kwargs):
+def get_addict(base):
+    class Addict(base):
         """
-        If we're initialized with a dict, make sure we turn all the
-        subdicts into Dicts as well.
+        Addict is a subclass of dict, which allows you to get AND SET(!!)
+        items in the dict using the attribute syntax!
+
+        When you previously had to write:
+
+        my_dict = {'a': {'b': {'c': [1, 2, 3]}}}
+
+        you can now do the same simply by:
+
+        my_Addict = Addict()
+        my_Addict.a.b.c = [1, 2, 3]
+
+        Or for instance, if you'd like to add some additional stuff,
+        where you'd with the normal dict would write
+
+        my_dict['a']['b']['d'] = [4, 5, 6],
+
+        you may now do the AWESOME
+
+        my_Addict.a.b.d = [4, 5, 6]
+
+        instead. But hey, you can always use the same syntax as a regular dict,
+        however, this will not raise TypeErrors or AttributeErrors at any time
+        while you try to get an item. A lot like a defaultdict.
 
         """
-        for arg in args:
-            if not arg:
-                continue
-            elif isinstance(arg, dict):
-                for key, val in arg.items():
-                    self[key] = val
-            elif isinstance(arg, tuple) and (not isinstance(arg[0], tuple)):
-                self[arg[0]] = arg[1]
-            elif isinstance(arg, (list, tuple)) or isgenerator(arg):
-                for key, val in arg:
-                    self[key] = val
-            else:
-                raise TypeError("Dict does not understand "
-                                "{0} types".format(type(arg)))
 
-        for key, val in kwargs.items():
-            self[key] = val
+        def __init__(self, *args, **kwargs):
+            """
+            If we're initialized with a dict, make sure we turn all the
+            subdicts into Addicts as well.
 
-    def __setattr__(self, name, value):
-        """
-        setattr is called when the syntax a.b = 2 is used to set a value.
-
-        """
-        if hasattr(Dict, name):
-            raise AttributeError("'Dict' object attribute "
-                                 "'{0}' is read-only".format(name))
-        else:
-            self[name] = value
-
-    def __setitem__(self, name, value):
-        """
-        This is called when trying to set a value of the Dict using [].
-        E.g. some_instance_of_Dict['b'] = val. If 'val
-
-        """
-        value = self._hook(value)
-        super(Dict, self).__setitem__(name, value)
-
-    @classmethod
-    def _hook(cls, item):
-        """
-        Called to ensure that each dict-instance that are being set
-        is a addict Dict. Recurses.
-
-        """
-        if isinstance(item, dict):
-            return cls(item)
-        elif isinstance(item, (list, tuple)):
-            return type(item)(cls._hook(elem) for elem in item)
-        return item
-
-    def __getattr__(self, item):
-        return self.__getitem__(item)
-
-    def __getitem__(self, name):
-        """
-        This is called when the Dict is accessed by []. E.g.
-        some_instance_of_Dict['a'];
-        If the name is in the dict, we return it. Otherwise we set both
-        the attr and item to a new instance of Dict.
-
-        """
-        if name not in self:
-            self[name] = Dict()
-        return super(Dict, self).__getitem__(name)
-
-    def __delattr__(self, name):
-        """ Is invoked when del some_addict.b is called. """
-        del self[name]
-
-    _re_pattern = re.compile('[a-zA-Z_][a-zA-Z0-9_]*')
-
-    def __dir__(self):
-        """
-        Return a list of addict object attributes.
-        This includes key names of any dict entries, filtered to the subset of
-        valid attribute names (e.g. alphanumeric strings beginning with a
-        letter or underscore).  Also includes attributes of parent dict class.
-        """
-        dict_keys = []
-        for k in self.keys():
-            if isinstance(k, str):
-                m = self._re_pattern.match(k)
-                if m:
-                    dict_keys.append(m.string)
-
-        obj_attrs = list(dir(Dict))
-
-        return dict_keys + obj_attrs
-
-    def __str__(self):
-        return '{{{}}}'.format(', '.join(
-            ["'{}': {}".format(key, value) for key, value in self.items()]))
-
-    def _ipython_display_(self):
-        print(str(self))    # pragma: no cover
-
-    def _repr_html_(self):
-        return str(self)
-
-    def prune(self, prune_zero=False, prune_empty_list=True):
-        """
-        Removes all empty Dicts and falsy stuff inside the Dict.
-        E.g
-        >>> a = Dict()
-        >>> a.b.c.d
-        {}
-        >>> a.a = 2
-        >>> a
-        {'a': 2, 'b': {'c': {'d': {}}}}
-        >>> a.prune()
-        >>> a
-        {'a': 2}
-
-        Set prune_zero=True to remove 0 values
-        E.g
-        >>> a = Dict()
-        >>> a.b.c.d = 0
-        >>> a.prune(prune_zero=True)
-        >>> a
-        {}
-
-        Set prune_empty_list=False to have them persist
-        E.g
-        >>> a = Dict({'a': []})
-        >>> a.prune()
-        >>> a
-        {}
-        >>> a = Dict({'a': []})
-        >>> a.prune(prune_empty_list=False)
-        >>> a
-        {'a': []}
-        """
-        for key, val in list(self.items()):
-            if ((not val) and ((val != 0) or prune_zero) and
-                    not isinstance(val, list)):
-                del self[key]
-            elif isinstance(val, Dict):
-                val.prune(prune_zero, prune_empty_list)
-                if not val:
-                    del self[key]
-            elif isinstance(val, (list, tuple)):
-                new_iter = self._prune_iter(val, prune_zero, prune_empty_list)
-                if (not new_iter) and prune_empty_list:
-                    del self[key]
+            """
+            for arg in args:
+                if not arg:
+                    continue
+                elif isinstance(arg, dict):
+                    for key, val in arg.items():
+                        self[key] = val
+                elif isinstance(arg, tuple) and (not isinstance(arg[0], tuple)):
+                    self[arg[0]] = arg[1]
+                elif isinstance(arg, (list, tuple)) or isgenerator(arg):
+                    for key, val in arg:
+                        self[key] = val
                 else:
-                    if isinstance(val, tuple):
-                        new_iter = tuple(new_iter)
-                    self[key] = new_iter
+                    raise TypeError("Addict does not understand "
+                                    "{0} types".format(type(arg)))
 
-    @classmethod
-    def _prune_iter(cls, some_iter, prune_zero=False, prune_empty_list=True):
+            for key, val in kwargs.items():
+                self[key] = val
 
-        new_iter = []
-        for item in some_iter:
-            if item == 0 and prune_zero:
-                continue
-            elif isinstance(item, Dict):
-                item.prune(prune_zero, prune_empty_list)
-                if item:
-                    new_iter.append(item)
+        def __setattr__(self, name, value):
+            """
+            setattr is called when the syntax a.b = 2 is used to set a value.
+
+            """
+            if hasattr(Addict, name):
+                raise AttributeError("'Addict' object attribute "
+                                     "'{0}' is read-only".format(name))
+            else:
+                self[name] = value
+
+        def __setitem__(self, name, value):
+            """
+            This is called when trying to set a value of the Addict using [].
+            E.g. some_instance_of_Addict['b'] = val. If 'val
+
+            """
+            value = self._hook(value)
+            super(Addict, self).__setitem__(name, value)
+
+        @classmethod
+        def _hook(cls, item):
+            """
+            Called to ensure that each dict-instance that are being set
+            is a addict Addict. Recurses.
+
+            """
+            if isinstance(item, dict):
+                return cls(item)
             elif isinstance(item, (list, tuple)):
-                new_item = type(item)(
-                    cls._prune_iter(item, prune_zero, prune_empty_list))
-                if new_item or not prune_empty_list:
-                    new_iter.append(new_item)
-            else:
-                new_iter.append(item)
-        return new_iter
+                return type(item)(cls._hook(elem) for elem in item)
+            return item
 
-    def to_dict(self):
-        """ Recursively turn your addict Dicts into dicts. """
-        base = {}
-        for key, value in self.items():
-            if isinstance(value, type(self)):
-                base[key] = value.to_dict()
-            elif isinstance(value, (list, tuple)):
-                base[key] = type(value)(
-                    item.to_dict() if isinstance(item, type(self)) else
-                    item for item in value)
-            else:
-                base[key] = value
-        return base
+        def __getattr__(self, item):
+            return self.__getitem__(item)
 
-    def copy(self):
-        """
-        Return a disconnected deep copy of self. Children of type Dict, list
-        and tuple are copied recursively while values that are instances of
-        other mutable objects are not copied.
+        def __getitem__(self, name):
+            """
+            This is called when the Addict is accessed by []. E.g.
+            some_instance_of_Addict['a'];
+            If the name is in the dict, we return it. Otherwise we set both
+            the attr and item to a new instance of Addict.
 
-        """
-        return Dict(self.to_dict())
+            """
+            if name not in self:
+                self[name] = Addict()
+            return super(Addict, self).__getitem__(name)
 
-    def __deepcopy__(self, memo):
-        """ Return a disconnected deep copy of self. """
+        def __delattr__(self, name):
+            """ Is invoked when del some_addict.b is called. """
+            del self[name]
 
-        y = self.__class__()
-        memo[id(self)] = y
-        for key, value in self.items():
-            y[copy.deepcopy(key, memo)] = copy.deepcopy(value, memo)
-        return y
+        _re_pattern = re.compile('[a-zA-Z_][a-zA-Z0-9_]*')
 
-    def update(self, d):
-        """ Recursively merge d into self. """
+        def __dir__(self):
+            """
+            Return a list of addict object attributes.
+            This includes key names of any dict entries, filtered to the subset
+            of valid attribute names (e.g. alphanumeric strings beginning with a
+            letter or underscore).  Also includes attributes of parent dict
+            class.
+            """
+            dict_keys = []
+            for k in self.keys():
+                if isinstance(k, str):
+                    m = self._re_pattern.match(k)
+                    if m:
+                        dict_keys.append(m.string)
 
-        for k, v in d.items():
-            if ((k not in self) or
-                (not isinstance(self[k], dict)) or
-                (not isinstance(v, dict))):
-                self[k] = v
-            else:
-                self[k].update(v)
+            obj_attrs = list(dir(Addict))
+
+            return dict_keys + obj_attrs
+
+        def __str__(self):
+            return '{{{}}}'.format(', '.join(
+                ["'{}': {}".format(key, value) for key, value in self.items()]))
+
+        def _ipython_display_(self):
+            print(str(self))    # pragma: no cover
+
+        def _repr_html_(self):
+            return str(self)
+
+        def prune(self, prune_zero=False, prune_empty_list=True):
+            """
+            Removes all empty Addicts and falsy stuff inside the Addict.
+            E.g
+            >>> a = Addict()
+            >>> a.b.c.d
+            {}
+            >>> a.a = 2
+            >>> a
+            {'a': 2, 'b': {'c': {'d': {}}}}
+            >>> a.prune()
+            >>> a
+            {'a': 2}
+
+            Set prune_zero=True to remove 0 values
+            E.g
+            >>> a = Addict()
+            >>> a.b.c.d = 0
+            >>> a.prune(prune_zero=True)
+            >>> a
+            {}
+
+            Set prune_empty_list=False to have them persist
+            E.g
+            >>> a = Addict({'a': []})
+            >>> a.prune()
+            >>> a
+            {}
+            >>> a = Addict({'a': []})
+            >>> a.prune(prune_empty_list=False)
+            >>> a
+            {'a': []}
+            """
+            for key, val in list(self.items()):
+                if ((not val) and ((val != 0) or prune_zero) and
+                        not isinstance(val, list)):
+                    del self[key]
+                elif isinstance(val, Addict):
+                    val.prune(prune_zero, prune_empty_list)
+                    if not val:
+                        del self[key]
+                elif isinstance(val, (list, tuple)):
+                    new_iter = self._prune_iter(val, prune_zero,
+                                                prune_empty_list)
+                    if (not new_iter) and prune_empty_list:
+                        del self[key]
+                    else:
+                        if isinstance(val, tuple):
+                            new_iter = tuple(new_iter)
+                        self[key] = new_iter
+
+        @classmethod
+        def _prune_iter(cls, some_iter, prune_zero=False,
+                        prune_empty_list=True):
+            new_iter = []
+            for item in some_iter:
+                if item == 0 and prune_zero:
+                    continue
+                elif isinstance(item, Addict):
+                    item.prune(prune_zero, prune_empty_list)
+                    if item:
+                        new_iter.append(item)
+                elif isinstance(item, (list, tuple)):
+                    new_item = type(item)(
+                        cls._prune_iter(item, prune_zero, prune_empty_list))
+                    if new_item or not prune_empty_list:
+                        new_iter.append(new_item)
+                else:
+                    new_iter.append(item)
+            return new_iter
+
+        def to_dict(self):
+            """ Recursively turn your addict Addicts into dicts. """
+            base = {}
+            for key, value in self.items():
+                if isinstance(value, type(self)):
+                    base[key] = value.to_dict()
+                elif isinstance(value, (list, tuple)):
+                    base[key] = type(value)(
+                        item.to_dict() if isinstance(item, type(self)) else
+                        item for item in value)
+                else:
+                    base[key] = value
+            return base
+
+        def copy(self):
+            """
+            Return a disconnected deep copy of self. Children of type Addict,
+            list and tuple are copied recursively while values that are
+            instances of other mutable objects are not copied.
+
+            """
+            return Addict(self.to_dict())
+
+        def __deepcopy__(self, memo):
+            """ Return a disconnected deep copy of self. """
+
+            y = self.__class__()
+            memo[id(self)] = y
+            for key, value in self.items():
+                y[copy.deepcopy(key, memo)] = copy.deepcopy(value, memo)
+            return y
+
+        def update(self, d):
+            """ Recursively merge d into self. """
+
+            for k, v in d.items():
+                if ((k not in self) or (not isinstance(self[k], dict)) or
+                        (not isinstance(v, dict))):
+                    self[k] = v
+                else:
+                    self[k].update(v)
+
+    return Addict
+
+
+Dict = get_addict(dict)
+OrderedDict = get_addict(CollectionsOrderedDict)

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -1,261 +1,267 @@
+"""
+addict allows you to get AND SET(!!) items in a dict using the
+attribute syntax!
+
+When you previously had to write:
+
+my_dict = {'a': {'b': {'c': [1, 2, 3]}}}
+
+you can now do the same simply by:
+
+my_dict = Dict()
+my_dict.a.b.c = [1, 2, 3]
+
+Or for instance, if you'd like to add some additional stuff,
+where you'd with the normal dict would write
+
+my_dict['a']['b']['d'] = [4, 5, 6],
+
+you may now do the AWESOME
+
+my_dict.a.b.d = [4, 5, 6]
+
+instead. But hey, you can always use the same syntax as a regular dict,
+however, this will not raise TypeErrors or AttributeErrors at any time
+while you try to get an item. A lot like a defaultdict.
+
+"""
+
 from inspect import isgenerator
 import re
 import copy
-from collections import OrderedDict as CollectionsOrderedDict
+from collections import OrderedDict as BaseOrderedDict
 
 
-def get_addict(base):
-    class Addict(base):
+class AbstractAddict():
+    """
+    Abstract base class that will add addicts feature set to any dict
+    based base class.
+    """
+
+    def __init__(self, *args, **kwargs):
         """
-        Addict is a subclass of dict, which allows you to get AND SET(!!)
-        items in the dict using the attribute syntax!
-
-        When you previously had to write:
-
-        my_dict = {'a': {'b': {'c': [1, 2, 3]}}}
-
-        you can now do the same simply by:
-
-        my_Addict = Addict()
-        my_Addict.a.b.c = [1, 2, 3]
-
-        Or for instance, if you'd like to add some additional stuff,
-        where you'd with the normal dict would write
-
-        my_dict['a']['b']['d'] = [4, 5, 6],
-
-        you may now do the AWESOME
-
-        my_Addict.a.b.d = [4, 5, 6]
-
-        instead. But hey, you can always use the same syntax as a regular dict,
-        however, this will not raise TypeErrors or AttributeErrors at any time
-        while you try to get an item. A lot like a defaultdict.
+        If we're initialized with a dict, make sure we turn all the
+        subdicts into addicts as well.
 
         """
-
-        def __init__(self, *args, **kwargs):
-            """
-            If we're initialized with a dict, make sure we turn all the
-            subdicts into Addicts as well.
-
-            """
-            for arg in args:
-                if not arg:
-                    continue
-                elif isinstance(arg, dict):
-                    for key, val in arg.items():
-                        self[key] = val
-                elif isinstance(arg, tuple) and (not isinstance(arg[0], tuple)):
-                    self[arg[0]] = arg[1]
-                elif isinstance(arg, (list, tuple)) or isgenerator(arg):
-                    for key, val in arg:
-                        self[key] = val
-                else:
-                    raise TypeError("Addict does not understand "
-                                    "{0} types".format(type(arg)))
-
-            for key, val in kwargs.items():
-                self[key] = val
-
-        def __setattr__(self, name, value):
-            """
-            setattr is called when the syntax a.b = 2 is used to set a value.
-
-            """
-            if hasattr(Addict, name):
-                raise AttributeError("'Addict' object attribute "
-                                     "'{0}' is read-only".format(name))
+        for arg in args:
+            if not arg:
+                continue
+            elif isinstance(arg, dict):
+                for key, val in arg.items():
+                    self[key] = val
+            elif isinstance(arg, tuple) and (not isinstance(arg[0], tuple)):
+                self[arg[0]] = arg[1]
+            elif isinstance(arg, (list, tuple)) or isgenerator(arg):
+                for key, val in arg:
+                    self[key] = val
             else:
-                self[name] = value
+                raise TypeError("addict does not understand "
+                                "{0} types".format(type(arg)))
 
-        def __setitem__(self, name, value):
-            """
-            This is called when trying to set a value of the Addict using [].
-            E.g. some_instance_of_Addict['b'] = val. If 'val
+        for key, val in kwargs.items():
+            self[key] = val
 
-            """
-            value = self._hook(value)
-            super(Addict, self).__setitem__(name, value)
+    def __setattr__(self, name, value):
+        """
+        setattr is called when the syntax a.b = 2 is used to set a value.
 
-        @classmethod
-        def _hook(cls, item):
-            """
-            Called to ensure that each dict-instance that are being set
-            is a addict Addict. Recurses.
+        """
+        if hasattr(self.__class__, name):
+            raise AttributeError("'addict' object attribute "
+                                 "'{0}' is read-only".format(name))
+        else:
+            self[name] = value
 
-            """
-            if isinstance(item, dict):
-                return cls(item)
-            elif isinstance(item, (list, tuple)):
-                return type(item)(cls._hook(elem) for elem in item)
-            return item
+    def __setitem__(self, name, value):
+        """
+        This is called when trying to set a value of the addict using [].
+        E.g. some_instance_of_addict['b'] = val. If 'val
 
-        def __getattr__(self, item):
-            return self.__getitem__(item)
+        """
+        value = self._hook(value)
+        super(AbstractAddict, self).__setitem__(name, value)
 
-        def __getitem__(self, name):
-            """
-            This is called when the Addict is accessed by []. E.g.
-            some_instance_of_Addict['a'];
-            If the name is in the dict, we return it. Otherwise we set both
-            the attr and item to a new instance of Addict.
+    @classmethod
+    def _hook(cls, item):
+        """
+        Called to ensure that each dict-instance that are being set
+        is an addict addict. Recurses.
 
-            """
-            if name not in self:
-                self[name] = Addict()
-            return super(Addict, self).__getitem__(name)
+        """
+        if isinstance(item, dict):
+            return cls(item)
+        elif isinstance(item, (list, tuple)):
+            return type(item)(cls._hook(elem) for elem in item)
+        return item
 
-        def __delattr__(self, name):
-            """ Is invoked when del some_addict.b is called. """
-            del self[name]
+    def __getattr__(self, item):
+        return self.__getitem__(item)
 
-        _re_pattern = re.compile('[a-zA-Z_][a-zA-Z0-9_]*')
+    def __getitem__(self, name):
+        """
+        This is called when the addict is accessed by []. E.g.
+        some_instance_of_addict['a'];
+        If the name is in the dict, we return it. Otherwise we set both
+        the attr and item to a new instance of addict.
 
-        def __dir__(self):
-            """
-            Return a list of addict object attributes.
-            This includes key names of any dict entries, filtered to the subset
-            of valid attribute names (e.g. alphanumeric strings beginning with a
-            letter or underscore).  Also includes attributes of parent dict
-            class.
-            """
-            dict_keys = []
-            for k in self.keys():
-                if isinstance(k, str):
-                    m = self._re_pattern.match(k)
-                    if m:
-                        dict_keys.append(m.string)
+        """
+        if name not in self:
+            self[name] = self.__class__()
+        return super(AbstractAddict, self).__getitem__(name)
 
-            obj_attrs = list(dir(Addict))
+    def __delattr__(self, name):
+        """ Is invoked when del some_addict.b is called. """
+        del self[name]
 
-            return dict_keys + obj_attrs
+    _re_pattern = re.compile('[a-zA-Z_][a-zA-Z0-9_]*')
 
-        def __str__(self):
-            return '{{{}}}'.format(', '.join(
-                ["'{}': {}".format(key, value) for key, value in self.items()]))
+    def __dir__(self):
+        """
+        Return a list of addict object attributes.
+        This includes key names of any dict entries, filtered to the subset
+        of valid attribute names (e.g. alphanumeric strings beginning with a
+        letter or underscore).  Also includes attributes of parent dict
+        class.
+        """
+        dict_keys = []
+        for k in self.keys():
+            if isinstance(k, str):
+                m = self._re_pattern.match(k)
+                if m:
+                    dict_keys.append(m.string)
 
-        def _ipython_display_(self):
-            print(str(self))    # pragma: no cover
+        obj_attrs = list(dir(self.__class__))
 
-        def _repr_html_(self):
-            return str(self)
+        return dict_keys + obj_attrs
 
-        def prune(self, prune_zero=False, prune_empty_list=True):
-            """
-            Removes all empty Addicts and falsy stuff inside the Addict.
-            E.g
-            >>> a = Addict()
-            >>> a.b.c.d
-            {}
-            >>> a.a = 2
-            >>> a
-            {'a': 2, 'b': {'c': {'d': {}}}}
-            >>> a.prune()
-            >>> a
-            {'a': 2}
+    def __str__(self):
+        return '{{{}}}'.format(', '.join(
+            ["'{}': {}".format(key, value) for key, value in self.items()]))
 
-            Set prune_zero=True to remove 0 values
-            E.g
-            >>> a = Addict()
-            >>> a.b.c.d = 0
-            >>> a.prune(prune_zero=True)
-            >>> a
-            {}
+    def _ipython_display_(self):
+        print(str(self))    # pragma: no cover
 
-            Set prune_empty_list=False to have them persist
-            E.g
-            >>> a = Addict({'a': []})
-            >>> a.prune()
-            >>> a
-            {}
-            >>> a = Addict({'a': []})
-            >>> a.prune(prune_empty_list=False)
-            >>> a
-            {'a': []}
-            """
-            for key, val in list(self.items()):
-                if ((not val) and ((val != 0) or prune_zero) and
-                        not isinstance(val, list)):
+    def _repr_html_(self):
+        return str(self)
+
+    def prune(self, prune_zero=False, prune_empty_list=True):
+        """
+        Removes all empty addicts and falsy stuff inside the addict.
+        E.g
+        >>> a = Dict()
+        >>> a.b.c.d
+        {}
+        >>> a.a = 2
+        >>> a
+        {'a': 2, 'b': {'c': {'d': {}}}}
+        >>> a.prune()
+        >>> a
+        {'a': 2}
+
+        Set prune_zero=True to remove 0 values
+        E.g
+        >>> a = Dict()
+        >>> a.b.c.d = 0
+        >>> a.prune(prune_zero=True)
+        >>> a
+        {}
+
+        Set prune_empty_list=False to have them persist
+        E.g
+        >>> a = Dict({'a': []})
+        >>> a.prune()
+        >>> a
+        {}
+        >>> a = Dict({'a': []})
+        >>> a.prune(prune_empty_list=False)
+        >>> a
+        {'a': []}
+        """
+        for key, val in list(self.items()):
+            if ((not val) and ((val != 0) or prune_zero) and
+                    not isinstance(val, list)):
+                del self[key]
+            elif isinstance(val, self.__class__):
+                val.prune(prune_zero, prune_empty_list)
+                if not val:
                     del self[key]
-                elif isinstance(val, Addict):
-                    val.prune(prune_zero, prune_empty_list)
-                    if not val:
-                        del self[key]
-                elif isinstance(val, (list, tuple)):
-                    new_iter = self._prune_iter(val, prune_zero,
-                                                prune_empty_list)
-                    if (not new_iter) and prune_empty_list:
-                        del self[key]
-                    else:
-                        if isinstance(val, tuple):
-                            new_iter = tuple(new_iter)
-                        self[key] = new_iter
-
-        @classmethod
-        def _prune_iter(cls, some_iter, prune_zero=False,
-                        prune_empty_list=True):
-            new_iter = []
-            for item in some_iter:
-                if item == 0 and prune_zero:
-                    continue
-                elif isinstance(item, Addict):
-                    item.prune(prune_zero, prune_empty_list)
-                    if item:
-                        new_iter.append(item)
-                elif isinstance(item, (list, tuple)):
-                    new_item = type(item)(
-                        cls._prune_iter(item, prune_zero, prune_empty_list))
-                    if new_item or not prune_empty_list:
-                        new_iter.append(new_item)
+            elif isinstance(val, (list, tuple)):
+                new_iter = self._prune_iter(val, prune_zero,
+                                            prune_empty_list)
+                if (not new_iter) and prune_empty_list:
+                    del self[key]
                 else:
+                    if isinstance(val, tuple):
+                        new_iter = tuple(new_iter)
+                    self[key] = new_iter
+
+    @classmethod
+    def _prune_iter(cls, some_iter, prune_zero=False,
+                    prune_empty_list=True):
+        new_iter = []
+        for item in some_iter:
+            if item == 0 and prune_zero:
+                continue
+            elif isinstance(item, cls):
+                item.prune(prune_zero, prune_empty_list)
+                if item:
                     new_iter.append(item)
-            return new_iter
+            elif isinstance(item, (list, tuple)):
+                new_item = type(item)(
+                    cls._prune_iter(item, prune_zero, prune_empty_list))
+                if new_item or not prune_empty_list:
+                    new_iter.append(new_item)
+            else:
+                new_iter.append(item)
+        return new_iter
 
-        def to_dict(self):
-            """ Recursively turn your addict Addicts into dicts. """
-            base = {}
-            for key, value in self.items():
-                if isinstance(value, type(self)):
-                    base[key] = value.to_dict()
-                elif isinstance(value, (list, tuple)):
-                    base[key] = type(value)(
-                        item.to_dict() if isinstance(item, type(self)) else
-                        item for item in value)
-                else:
-                    base[key] = value
-            return base
+    def to_dict(self):
+        """ Recursively turn your addict addicts into dicts. """
+        base = {}
+        for key, value in self.items():
+            if isinstance(value, type(self)):
+                base[key] = value.to_dict()
+            elif isinstance(value, (list, tuple)):
+                base[key] = type(value)(
+                    item.to_dict() if isinstance(item, type(self)) else
+                    item for item in value)
+            else:
+                base[key] = value
+        return base
 
-        def copy(self):
-            """
-            Return a disconnected deep copy of self. Children of type Addict,
-            list and tuple are copied recursively while values that are
-            instances of other mutable objects are not copied.
+    def copy(self):
+        """
+        Return a disconnected deep copy of self. Children that extend
+        AbstractAddict, or that are of type list or tuple are copied
+        recursively while values that are instances of other mutable
+        objects are not copied.
+        """
+        return self.__class__(self.to_dict())
 
-            """
-            return Addict(self.to_dict())
+    def __deepcopy__(self, memo):
+        """ Return a disconnected deep copy of self. """
 
-        def __deepcopy__(self, memo):
-            """ Return a disconnected deep copy of self. """
+        y = self.__class__()
+        memo[id(self)] = y
+        for key, value in self.items():
+            y[copy.deepcopy(key, memo)] = copy.deepcopy(value, memo)
+        return y
 
-            y = self.__class__()
-            memo[id(self)] = y
-            for key, value in self.items():
-                y[copy.deepcopy(key, memo)] = copy.deepcopy(value, memo)
-            return y
+    def update(self, d):
+        """ Recursively merge d into self. """
 
-        def update(self, d):
-            """ Recursively merge d into self. """
-
-            for k, v in d.items():
-                if ((k not in self) or (not isinstance(self[k], dict)) or
-                        (not isinstance(v, dict))):
-                    self[k] = v
-                else:
-                    self[k].update(v)
-
-    return Addict
+        for k, v in d.items():
+            if ((k not in self) or (not isinstance(self[k], dict)) or
+                    (not isinstance(v, dict))):
+                self[k] = v
+            else:
+                self[k].update(v)
 
 
-Dict = get_addict(dict)
-OrderedDict = get_addict(CollectionsOrderedDict)
+class Dict(AbstractAddict, dict):
+    pass
+
+
+class OrderedDict(AbstractAddict, BaseOrderedDict):
+    pass

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -1,10 +1,10 @@
 from inspect import isgenerator
 import re
 import copy
+from collections import OrderedDict
 
 
-class Dict(dict):
-
+class Dict(OrderedDict):
     """
     Dict is a subclass of dict, which allows you to get AND SET(!!)
     items in the dict using the attribute syntax!
@@ -128,6 +128,10 @@ class Dict(dict):
         obj_attrs = list(dir(Dict))
 
         return dict_keys + obj_attrs
+
+    def __str__(self):
+        return '{{{}}}'.format(', '.join(
+            ["'{}': {}".format(key, value) for key, value in self.items()]))
 
     def _ipython_display_(self):
         print(str(self))    # pragma: no cover

--- a/test_addict.py
+++ b/test_addict.py
@@ -413,13 +413,13 @@ class BaseTests(unittest.TestCase):
 class DictTests(BaseTests):
     def __init__(self, *args, **kwargs):
         self.DictClass = Dict
-        super(BaseTests, self).__init__(*args, **kwargs)
+        super(DictTests, self).__init__(*args, **kwargs)
 
 
 class OrderedDictTests(BaseTests):
     def __init__(self, *args, **kwargs):
         self.DictClass = OrderedDict
-        super(BaseTests, self).__init__(*args, **kwargs)
+        super(OrderedDictTests, self).__init__(*args, **kwargs)
 
 
 """

--- a/test_addict.py
+++ b/test_addict.py
@@ -1,140 +1,140 @@
 import json
 import copy
 import unittest
-from addict import Dict
+from addict import Dict, OrderedDict
 
 TEST_VAL = [1, 2, 3]
 TEST_DICT = {'a': {'b': {'c': TEST_VAL}}}
 TEST_DICT_STR = str(TEST_DICT)
 
 
-class Tests(unittest.TestCase):
+class BaseTests(unittest.TestCase):
 
     def test_set_one_level_item(self):
         some_dict = {'a': TEST_VAL}
-        prop = Dict()
+        prop = self.DictClass()
         prop['a'] = TEST_VAL
         self.assertDictEqual(prop, some_dict)
 
     def test_set_two_level_items(self):
         some_dict = {'a': {'b': TEST_VAL}}
-        prop = Dict()
+        prop = self.DictClass()
         prop['a']['b'] = TEST_VAL
         self.assertDictEqual(prop, some_dict)
 
     def test_set_three_level_items(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop['a']['b']['c'] = TEST_VAL
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_set_one_level_property(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a = TEST_VAL
         self.assertDictEqual(prop, {'a': TEST_VAL})
 
     def test_set_two_level_properties(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b = TEST_VAL
         self.assertDictEqual(prop, {'a': {'b': TEST_VAL}})
 
     def test_set_three_level_properties(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b.c = TEST_VAL
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_init_with_dict(self):
-        self.assertDictEqual(TEST_DICT, Dict(TEST_DICT))
+        self.assertDictEqual(TEST_DICT, self.DictClass(TEST_DICT))
 
     def test_init_with_kws(self):
-        prop = Dict(a=2, b={'a': 2}, c=[{'a': 2}])
+        prop = self.DictClass(a=2, b={'a': 2}, c=[{'a': 2}])
         self.assertDictEqual(prop, {'a': 2, 'b': {'a': 2}, 'c': [{'a': 2}]})
 
     def test_init_with_tuples(self):
-        prop = Dict((0, 1), (1, 2), (2, 3))
+        prop = self.DictClass((0, 1), (1, 2), (2, 3))
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_list(self):
-        prop = Dict([(0, 1), (1, 2), (2, 3)])
+        prop = self.DictClass([(0, 1), (1, 2), (2, 3)])
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_generator(self):
-        prop = Dict(((i, i + 1) for i in range(3)))
+        prop = self.DictClass(((i, i + 1) for i in range(3)))
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_tuples_and_empty_list(self):
-        prop = Dict((0, 1), [], (2, 3))
+        prop = self.DictClass((0, 1), [], (2, 3))
         self.assertDictEqual(prop, {0: 1, 2: 3})
 
     def test_init_raises(self):
         def init():
-            Dict(5)
+            self.DictClass(5)
 
         def init2():
-            Dict('a')
+            self.DictClass('a')
         self.assertRaises(TypeError, init)
         self.assertRaises(TypeError, init2)
 
     def test_init_with_empty_stuff(self):
-        a = Dict({})
-        b = Dict([])
+        a = self.DictClass({})
+        b = self.DictClass([])
         self.assertDictEqual(a, {})
         self.assertDictEqual(b, {})
 
     def test_init_with_list_of_dicts(self):
-        a = Dict({'a': [{'b': 2}]})
-        self.assertIsInstance(a.a[0], Dict)
+        a = self.DictClass({'a': [{'b': 2}]})
+        self.assertIsInstance(a.a[0], self.DictClass)
         self.assertEqual(a.a[0].b, 2)
 
     def test_getitem(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         self.assertEqual(prop['a']['b']['c'], TEST_VAL)
 
     def test_getattr(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         self.assertEqual(prop.a.b.c, TEST_VAL)
 
     def test_isinstance(self):
-        self.assertTrue(isinstance(Dict(), dict))
+        self.assertTrue(isinstance(self.DictClass(), dict))
 
     def test_str(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         self.assertEqual(str(prop), str(TEST_DICT))
 
     def test_json(self):
         some_dict = TEST_DICT
         some_json = json.dumps(some_dict)
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b.c = TEST_VAL
         prop_json = json.dumps(prop)
         self.assertEqual(some_json, prop_json)
 
     def test_delitem(self):
-        prop = Dict({'a': 2})
+        prop = self.DictClass({'a': 2})
         del prop['a']
         self.assertDictEqual(prop, {})
 
     def test_delitem_nested(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         del prop['a']['b']['c']
         self.assertDictEqual(prop, {'a': {'b': {}}})
 
     def test_delattr(self):
-        prop = Dict({'a': 2})
+        prop = self.DictClass({'a': 2})
         del prop.a
         self.assertDictEqual(prop, {})
 
     def test_delattr_nested(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         del prop.a.b.c
         self.assertDictEqual(prop, {'a': {'b': {}}})
 
     def test_delitem_delattr(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         del prop.a['b']
         self.assertDictEqual(prop, {'a': {}})
 
     def test_prune(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b.c.d
         prop.b
         prop.c = 2
@@ -142,103 +142,103 @@ class Tests(unittest.TestCase):
         self.assertDictEqual(prop, {'c': 2})
 
     def test_prune_nested(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         prop.b.c.d
         prop.d
         prop.prune()
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_prune_empty_list(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         prop.b.c = []
         prop.prune()
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_prune_shared_key(self):
-        prop = Dict(TEST_DICT)
+        prop = self.DictClass(TEST_DICT)
         prop.a.b.d
         prop.prune()
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_prune_dont_remove_zero(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a = 0
         prop.b.c
         prop.prune()
         self.assertDictEqual(prop, {'a': 0})
 
     def test_prune_with_list(self):
-        prop = Dict()
-        prop.a = [Dict(), Dict(), Dict()]
+        prop = self.DictClass()
+        prop.a = [self.DictClass(), self.DictClass(), self.DictClass()]
         prop.a[0].b.c = 2
         prop.prune()
         self.assertDictEqual(prop, {'a': [{'b': {'c': 2}}]})
 
     def test_prune_with_tuple(self):
-        prop = Dict()
-        prop.a = (Dict(), Dict(), Dict())
+        prop = self.DictClass()
+        prop.a = (self.DictClass(), self.DictClass(), self.DictClass())
         prop.a[0].b.c = 2
         prop.prune()
         self.assertDictEqual(prop, {'a': ({'b': {'c': 2}}, )})
 
     def test_prune_list(self):
-        l = [Dict(), Dict(), Dict()]
+        l = [self.DictClass(), self.DictClass(), self.DictClass()]
         l[0].a.b = 2
-        l1 = Dict._prune_iter(l)
+        l1 = self.DictClass._prune_iter(l)
         self.assertSequenceEqual(l1, [{'a': {'b': 2}}])
 
     def test_prune_tuple(self):
-        l = (Dict(), Dict(), Dict())
+        l = (self.DictClass(), self.DictClass(), self.DictClass())
         l[0].a.b = 2
-        l1 = Dict._prune_iter(l)
+        l1 = self.DictClass._prune_iter(l)
         self.assertSequenceEqual(l1, [{'a': {'b': 2}}])
 
     def test_prune_not_new_list(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b = []
         prop.b = 2
         prop.prune()
         self.assertDictEqual(prop, {'b': 2})
 
     def test_iter_reduce_with_list(self):
-        prop = Dict()
-        prop.a = [Dict(), 1, 2]
+        prop = self.DictClass()
+        prop.a = [self.DictClass(), 1, 2]
         prop.a[0].b.c
         prop.prune()
         self.assertDictEqual(prop, {'a': [1, 2]})
 
     def test_iter_reduce_with_tuple(self):
-        prop = Dict()
-        prop.a = (Dict(), 1, 2)
+        prop = self.DictClass()
+        prop.a = (self.DictClass(), 1, 2)
         prop.a[0].b.c
         prop.prune()
         self.assertDictEqual(prop, {'a': (1, 2)})
 
     def test_prune_nested_list(self):
-        prop = Dict()
-        prop.a = [Dict(), [[]], [1, 2, 3]]
+        prop = self.DictClass()
+        prop.a = [self.DictClass(), [[]], [1, 2, 3]]
         prop.prune()
         self.assertDictEqual(prop, {'a': [[1, 2, 3]]})
 
     def test_complex_nested_structure(self):
-        prop = Dict()
-        prop.a = [(Dict(), 2), [[]], [1, (2, 3), 0]]
+        prop = self.DictClass()
+        prop.a = [(self.DictClass(), 2), [[]], [1, (2, 3), 0]]
         prop.prune(prune_zero=True)
         self.assertDictEqual(prop, {'a': [(2,), [1, (2, 3)]]})
 
     def test_tuple_key(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop[(1, 2)] = 2
         self.assertDictEqual(prop, {(1, 2): 2})
         self.assertEqual(prop[(1, 2)], 2)
 
     def test_repr_html(self):
-        prop = Dict()
+        prop = self.DictClass()
         prop.a.b.c = TEST_VAL
         self.assertEqual(prop._repr_html_(), TEST_DICT_STR)
 
     def test_set_prop_invalid(self):
-        prop = Dict()
+        prop = self.DictClass()
 
         def set_keys():
             prop.keys = 2
@@ -252,10 +252,10 @@ class Tests(unittest.TestCase):
 
     def test_dir(self):
         key = 'a'
-        prop = Dict({key: 1})
+        prop = self.DictClass({key: 1})
         dir_prop = dir(prop)
 
-        dir_dict = dir(Dict)
+        dir_dict = dir(self.DictClass)
         for d in dir_dict:
             self.assertTrue(d in dir_prop, d)
 
@@ -265,47 +265,47 @@ class Tests(unittest.TestCase):
         self.assertTrue('__members__' not in dir_prop)
 
     def test_dir_with_members(self):
-        prop = Dict({'__members__': 1})
+        prop = self.DictClass({'__members__': 1})
         dir(prop)
         self.assertTrue('__members__' in prop.keys())
 
     def test_prune_zero(self):
-        prop = Dict({'a': 1, 'c': 0})
+        prop = self.DictClass({'a': 1, 'c': 0})
         prop.prune(prune_zero=True)
         self.assertDictEqual(prop, {'a': 1})
 
     def test_prune_zero_nested(self):
-        prop = Dict({'a': 1, 'c': {'d': 0}})
+        prop = self.DictClass({'a': 1, 'c': {'d': 0}})
         prop.prune(prune_zero=True)
         self.assertDictEqual(prop, {'a': 1})
 
     def test_prune_zero_in_tuple(self):
-        prop = Dict({'a': 1, 'c': (1, 0)})
+        prop = self.DictClass({'a': 1, 'c': (1, 0)})
         prop.prune(prune_zero=True)
         self.assertDictEqual(prop, {'a': 1, 'c': (1, )})
 
     def test_prune_empty_list_nested(self):
-        prop = Dict({'a': 1, 'c': {'d': []}})
+        prop = self.DictClass({'a': 1, 'c': {'d': []}})
         prop.prune()
         self.assertDictEqual(prop, {'a': 1})
 
     def test_not_prune_empty_list_nested(self):
-        prop = Dict({'a': 1, 'c': ([], )})
+        prop = self.DictClass({'a': 1, 'c': ([], )})
         prop.prune(prune_empty_list=False)
         self.assertDictEqual(prop, {'a': 1, 'c': ([], )})
 
     def test_do_not_prune_empty_list_nested(self):
-        prop = Dict({'a': 1, 'c': {'d': []}})
+        prop = self.DictClass({'a': 1, 'c': {'d': []}})
         prop.prune(prune_empty_list=False)
         self.assertDictEqual(prop, {'a': 1, 'c': {'d': []}})
 
     def test_to_dict(self):
         nested = {'a': [{'a': 0}, 2], 'b': {}, 'c': 2}
-        prop = Dict(nested)
+        prop = self.DictClass(nested)
         regular = prop.to_dict()
         self.assertDictEqual(regular, prop)
         self.assertDictEqual(regular, nested)
-        self.assertNotIsInstance(regular, Dict)
+        self.assertNotIsInstance(regular, self.DictClass)
 
         def get_attr():
             regular.a = 2
@@ -317,20 +317,20 @@ class Tests(unittest.TestCase):
 
     def test_to_dict_with_tuple(self):
         nested = {'a': ({'a': 0}, {2: 0})}
-        prop = Dict(nested)
+        prop = self.DictClass(nested)
         regular = prop.to_dict()
         self.assertDictEqual(regular, prop)
         self.assertDictEqual(regular, nested)
         self.assertIsInstance(regular['a'], tuple)
-        self.assertNotIsInstance(regular['a'][0], Dict)
+        self.assertNotIsInstance(regular['a'][0], self.DictClass)
 
     def test_update(self):
-        old = Dict()
+        old = self.DictClass()
         old.child.a = 'old a'
         old.child.b = 'old b'
         old.foo = 'no dict'
 
-        new = Dict()
+        new = self.DictClass()
         new.child.b = 'new b'
         new.child.c = 'new c'
         new.foo.now_my_papa_is_a_dict = True
@@ -343,9 +343,9 @@ class Tests(unittest.TestCase):
         self.assertDictEqual(old, reference)
 
     def test_update_with_lists(self):
-        org = Dict()
+        org = self.DictClass()
         org.a = [1, 2, {'a': 'superman'}]
-        someother = Dict()
+        someother = self.DictClass()
         someother.b = [{'b': 123}]
         org.update(someother)
 
@@ -354,7 +354,7 @@ class Tests(unittest.TestCase):
 
         org.update(someother)
         self.assertDictEqual(org, correct)
-        self.assertIsInstance(org.b[0], Dict)
+        self.assertIsInstance(org.b[0], self.DictClass)
 
     def test_copy(self):
         class MyMutableObject(object):
@@ -365,7 +365,7 @@ class Tests(unittest.TestCase):
         foo = MyMutableObject()
         foo.attribute = True
 
-        a = Dict()
+        a = self.DictClass()
         a.child.immutable = 42
         a.child.mutable = foo
 
@@ -381,7 +381,7 @@ class Tests(unittest.TestCase):
 
         # changing child of b should not affect a
         b.child = "new stuff"
-        self.assertTrue(isinstance(a.child, Dict))
+        self.assertTrue(isinstance(a.child, self.DictClass))
 
     def test_deepcopy(self):
         class MyMutableObject(object):
@@ -391,7 +391,7 @@ class Tests(unittest.TestCase):
         foo = MyMutableObject()
         foo.attribute = True
 
-        a = Dict()
+        a = self.DictClass()
         a.child.immutable = 42
         a.child.mutable = foo
 
@@ -407,7 +407,19 @@ class Tests(unittest.TestCase):
 
         # changing child of b should not affect a
         b.child = "new stuff"
-        self.assertTrue(isinstance(a.child, Dict))
+        self.assertTrue(isinstance(a.child, self.DictClass))
+
+
+class DictTests(BaseTests):
+    def __init__(self, *args, **kwargs):
+        self.DictClass = Dict
+        super(BaseTests, self).__init__(*args, **kwargs)
+
+
+class OrderedDictTests(BaseTests):
+    def __init__(self, *args, **kwargs):
+        self.DictClass = OrderedDict
+        super(BaseTests, self).__init__(*args, **kwargs)
 
 
 """
@@ -415,5 +427,9 @@ Allow for these test cases to be run from the command line
 via `python test_addict.py`
 """
 if __name__ == '__main__':
-    all_tests = unittest.TestLoader().loadTestsFromTestCase(Tests)
-    unittest.TextTestRunner(verbosity=2).run(all_tests)
+    dict_tests = unittest.TestLoader().loadTestsFromTestCase(DictTests)
+    orderedDict_tests = unittest.TestLoader().loadTestsFromTestCase(
+        OrderedDictTests)
+
+    unittest.TextTestRunner(verbosity=2).run(dict_tests)
+    unittest.TextTestRunner(verbosity=2).run(orderedDict_tests)


### PR DESCRIPTION
I've created this pull request as an example to talk about, not expecting you to merge anything yet. To get it working with an OrderedDict base all I did was swap out the base class of Dict from dict to OrderedDict. Then I reimplemented the default __str__ behavior from dict to get the tests to pass (and because it's much more readable than the str of OrderedDict).

If we did want to keep the dict base as an option, we could instead just wrap the whole Dict class in a higher order function that returns it with the desired base, as the attached implementation works with dict or OrderedDict as the base.