### PR TITLE
Allow dict assigned to elements or slices of arrays to be hooked as well

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -83,6 +83,8 @@ class Dict(dict):
         is a addict Dict. Recurses.
 
         """
+        if isinstance(item, Dict):
+            return item
         if isinstance(item, dict):
             return cls(item)
         elif isinstance(item, (list, tuple)):
@@ -102,6 +104,8 @@ class Dict(dict):
         """
         if name not in self:
             self[name] = Dict()
+        else:
+            self[name] = self._hook(super(Dict, self).__getitem__(name))
         return super(Dict, self).__getitem__(name)
 
     def __delattr__(self, name):

--- a/test_addict.py
+++ b/test_addict.py
@@ -227,6 +227,14 @@ class Tests(unittest.TestCase):
         prop.prune(prune_zero=True)
         self.assertDictEqual(prop, {'a': [(2,), [1, (2, 3)]]})
 
+    def test_set_prop_in_array(self):
+        prop = Dict()
+        prop.a = [1, 2, 3]
+        prop.a[0] = {}
+        prop.a[0].b = "b"
+        self.assertDictEqual(prop, {'a':[{'b':'b'}, 2, 3]})
+
+
     def test_tuple_key(self):
         prop = Dict()
         prop[(1, 2)] = 2


### PR DESCRIPTION
This implementation hooks the arrays as they are leaving the addict. Also added test case for case which does not work as expected.

```python
prop = Dict()
prop.a = [1, 2, 3]
prop.a[0] = {}
prop.a[0].b = "b"
# alternatively:
prop.a[:] = [{'a':1, 'b':2}, {'c':3}]
print (prop.a[-1].c) # 3
```
