### PR TITLE
Define __add__

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -76,6 +76,15 @@ class Dict(dict):
         """
         super(Dict, self).__setitem__(name, value)
 
+    def __add__(self, other):
+        if len(self.keys()) == 0:
+            return other
+        else:
+            self_type = type(self).__name__
+            other_type = type(other).__name__
+            msg = "unsupported operand type(s) for +: '{}' and '{}'"
+            raise TypeError(msg.format(self_type, other_type))
+
     @classmethod
     def _hook(cls, item):
         """

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -77,7 +77,7 @@ class Dict(dict):
         super(Dict, self).__setitem__(name, value)
 
     def __add__(self, other):
-        if len(self.keys()) == 0:
+        if not self.keys():
             return other
         else:
             self_type = type(self).__name__

--- a/test_addict.py
+++ b/test_addict.py
@@ -436,6 +436,33 @@ class Tests(unittest.TestCase):
         a = Dict(TEST_DICT)
         self.assertEqual(a, pickle.loads(pickle.dumps(a)))
 
+    def test_add_on_empty_dict(self):
+        d = Dict()
+        d.x.y += 1
+
+        self.assertEqual(d.x.y, 1)
+
+    def test_add_on_non_empty_dict(self):
+        d = Dict()
+        d.x.y = 'defined'
+
+        with self.assertRaises(TypeError):
+            d.x += 1
+
+    def test_add_on_non_empty_value(self):
+        d = Dict()
+        d.x.y = 1
+        d.x.y += 1
+
+        self.assertEqual(d.x.y, 2)
+
+    def test_add_on_unsupported_type(self):
+        d = Dict()
+        d.x.y = 'str'
+
+        with self.assertRaises(TypeError):
+            d.x.y += 1
+
 
 """
 Allow for these test cases to be run from the command line


### PR DESCRIPTION
Defining `__add__` allows `Dict` to be used as a dynamic nested counter. Consider this list of dicts and say you want to count the # of red and the # of blue by month.

```python
data = [
    {'month': '2015-01', 'color': 'red'},
    {'month': '2015-01', 'color': 'blue'},
    {'month': '2015-01', 'color': 'red'},
    {'month': '2015-02', 'color': 'blue'},
    {'month': '2015-02', 'color': 'blue'},
    {'month': '2015-02', 'color': 'red'}
]
```
Prior to this PR, you need to do:

```python
from addict import Dict

counter = Dict()

for x in data:
    month = x['month']
    color = x['color']

    if month in counter:
        if color in counter[month]:
            counter[month][color] += 1
        else:
            counter[month][color] = 1
    else:
        counter[month][color] = 1

print counter
```

```
{'2015-02': {'blue': 2, 'red': 1}, '2015-01': {'blue': 1, 'red': 2}}
```

After this PR, you can simply do:

```python
from addict import Dict

counter = Dict()

for x in data:
    month = x['month']
    color = x['color']
    counter[month][color] += 1

print counter
```

```
{'2015-02': {'blue': 2, 'red': 1}, '2015-01': {'blue': 1, 'red': 2}}
```

This of course becomes very powerful and convenient when you want to count things nested by many levels.