### PR TITLE
Include versions tested on Travis in Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     author_email='mats@plysjbyen.net',
     classifiers=(
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This will show up on PyPI, making clear what is supported.