### PR TITLE
Fixed Subclassing Dict Issues (Issue #101)

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -22,14 +22,14 @@ class Dict(dict):
             __self[key] = __self._hook(val)
 
     def __setattr__(self, name, value):
-        if hasattr(Dict, name):
+        if hasattr(self.__class__, name):
             raise AttributeError("'Dict' object attribute "
                                  "'{0}' is read-only".format(name))
         else:
             self[name] = value
 
     def __setitem__(self, name, value):
-        super(Dict, self).__setitem__(name, value)
+        super().__setitem__(name, value)
         try:
             p = object.__getattribute__(self, '__parent')
             key = object.__getattribute__(self, '__key')
@@ -61,10 +61,8 @@ class Dict(dict):
     def __getattr__(self, item):
         return self.__getitem__(item)
 
-    def __getitem__(self, name):
-        if name not in self:
-            return Dict(__parent=self, __key=name)
-        return super(Dict, self).__getitem__(name)
+    def __missing__(self, name):
+        return self.__class__(__parent=self, __key=name)
 
     def __delattr__(self, name):
         del self[name]

--- a/test_addict.py
+++ b/test_addict.py
@@ -4,41 +4,51 @@ import unittest
 import pickle
 from addict import Dict
 
+
+# test whether unittests pass on child classes
+class CHILD_CLASS(Dict):
+    child_class_attribute = 'child class attribute'
+
+    def child_instance_attribute(self):
+        return 'child instance attribute'
+
+
 TEST_VAL = [1, 2, 3]
 TEST_DICT = {'a': {'b': {'c': TEST_VAL}}}
 
 
-class Tests(unittest.TestCase):
+class AbstractTestsClass(unittest.TestCase):
+    dict_class = None
 
     def test_set_one_level_item(self):
         some_dict = {'a': TEST_VAL}
-        prop = Dict()
+        prop = self.dict_class()
         prop['a'] = TEST_VAL
         self.assertDictEqual(prop, some_dict)
 
     def test_set_two_level_items(self):
         some_dict = {'a': {'b': TEST_VAL}}
-        prop = Dict()
+        prop = self.dict_class()
         prop['a']['b'] = TEST_VAL
         self.assertDictEqual(prop, some_dict)
 
     def test_set_three_level_items(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop['a']['b']['c'] = TEST_VAL
         self.assertDictEqual(prop, TEST_DICT)
 
     def test_set_one_level_property(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop.a = TEST_VAL
         self.assertDictEqual(prop, {'a': TEST_VAL})
 
     def test_set_two_level_properties(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop.a.b = TEST_VAL
         self.assertDictEqual(prop, {'a': {'b': TEST_VAL}})
 
     def test_set_three_level_properties(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop.a.b.c = TEST_VAL
         self.assertDictEqual(prop, TEST_DICT)
 
@@ -46,28 +56,28 @@ class Tests(unittest.TestCase):
         self.assertDictEqual(TEST_DICT, Dict(TEST_DICT))
 
     def test_init_with_kws(self):
-        prop = Dict(a=2, b={'a': 2}, c=[{'a': 2}])
+        prop = self.dict_class(a=2, b={'a': 2}, c=[{'a': 2}])
         self.assertDictEqual(prop, {'a': 2, 'b': {'a': 2}, 'c': [{'a': 2}]})
 
     def test_init_with_tuples(self):
-        prop = Dict((0, 1), (1, 2), (2, 3))
+        prop = self.dict_class((0, 1), (1, 2), (2, 3))
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_list(self):
-        prop = Dict([(0, 1), (1, 2), (2, 3)])
+        prop = self.dict_class([(0, 1), (1, 2), (2, 3)])
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_generator(self):
-        prop = Dict(((i, i + 1) for i in range(3)))
+        prop = self.dict_class(((i, i + 1) for i in range(3)))
         self.assertDictEqual(prop, {0: 1, 1: 2, 2: 3})
 
     def test_init_with_tuples_and_empty_list(self):
-        prop = Dict((0, 1), [], (2, 3))
+        prop = self.dict_class((0, 1), [], (2, 3))
         self.assertDictEqual(prop, {0: 1, 2: 3})
 
     def test_init_raises(self):
         def init():
-            Dict(5)
+            self.dict_class(5)
 
         def init2():
             Dict('a')
@@ -75,86 +85,86 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, init2)
 
     def test_init_with_empty_stuff(self):
-        a = Dict({})
-        b = Dict([])
+        a = self.dict_class({})
+        b = self.dict_class([])
         self.assertDictEqual(a, {})
         self.assertDictEqual(b, {})
 
     def test_init_with_list_of_dicts(self):
-        a = Dict({'a': [{'b': 2}]})
-        self.assertIsInstance(a.a[0], Dict)
+        a = self.dict_class({'a': [{'b': 2}]})
+        self.assertIsInstance(a.a[0], self.dict_class)
         self.assertEqual(a.a[0].b, 2)
 
     def test_init_with_kwargs(self):
-        a = Dict(a='b', c=dict(d='e', f=dict(g='h')))
+        a = self.dict_class(a='b', c=dict(d='e', f=dict(g='h')))
 
         self.assertEqual(a.a, 'b')
-        self.assertIsInstance(a.c, Dict)
+        self.assertIsInstance(a.c, self.dict_class)
 
         self.assertEqual(a.c.f.g, 'h')
-        self.assertIsInstance(a.c.f, Dict)
+        self.assertIsInstance(a.c.f, self.dict_class)
 
     def test_getitem(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         self.assertEqual(prop['a']['b']['c'], TEST_VAL)
 
     def test_empty_getitem(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop.a.b.c
         self.assertEqual(prop, {})
 
     def test_getattr(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         self.assertEqual(prop.a.b.c, TEST_VAL)
 
     def test_isinstance(self):
-        self.assertTrue(isinstance(Dict(), dict))
+        self.assertTrue(isinstance(self.dict_class(), dict))
 
     def test_str(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         self.assertEqual(str(prop), str(TEST_DICT))
 
     def test_json(self):
         some_dict = TEST_DICT
         some_json = json.dumps(some_dict)
-        prop = Dict()
+        prop = self.dict_class()
         prop.a.b.c = TEST_VAL
         prop_json = json.dumps(prop)
         self.assertEqual(some_json, prop_json)
 
     def test_delitem(self):
-        prop = Dict({'a': 2})
+        prop = self.dict_class({'a': 2})
         del prop['a']
         self.assertDictEqual(prop, {})
 
     def test_delitem_nested(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         del prop['a']['b']['c']
         self.assertDictEqual(prop, {'a': {'b': {}}})
 
     def test_delattr(self):
-        prop = Dict({'a': 2})
+        prop = self.dict_class({'a': 2})
         del prop.a
         self.assertDictEqual(prop, {})
 
     def test_delattr_nested(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         del prop.a.b.c
         self.assertDictEqual(prop, {'a': {'b': {}}})
 
     def test_delitem_delattr(self):
-        prop = Dict(TEST_DICT)
+        prop = self.dict_class(TEST_DICT)
         del prop.a['b']
         self.assertDictEqual(prop, {'a': {}})
 
     def test_tuple_key(self):
-        prop = Dict()
+        prop = self.dict_class()
         prop[(1, 2)] = 2
         self.assertDictEqual(prop, {(1, 2): 2})
         self.assertEqual(prop[(1, 2)], 2)
 
     def test_set_prop_invalid(self):
-        prop = Dict()
+        prop = self.dict_class()
 
         def set_keys():
             prop.keys = 2
@@ -168,10 +178,10 @@ class Tests(unittest.TestCase):
 
     def test_dir(self):
         key = 'a'
-        prop = Dict({key: 1})
+        prop = self.dict_class({key: 1})
         dir_prop = dir(prop)
 
-        dir_dict = dir(Dict)
+        dir_dict = dir(self.dict_class)
         for d in dir_dict:
             self.assertTrue(d in dir_prop, d)
 
@@ -179,17 +189,17 @@ class Tests(unittest.TestCase):
         self.assertTrue('__members__' not in dir_prop)
 
     def test_dir_with_members(self):
-        prop = Dict({'__members__': 1})
+        prop = self.dict_class({'__members__': 1})
         dir(prop)
         self.assertTrue('__members__' in prop.keys())
 
     def test_to_dict(self):
         nested = {'a': [{'a': 0}, 2], 'b': {}, 'c': 2}
-        prop = Dict(nested)
+        prop = self.dict_class(nested)
         regular = prop.to_dict()
         self.assertDictEqual(regular, prop)
         self.assertDictEqual(regular, nested)
-        self.assertNotIsInstance(regular, Dict)
+        self.assertNotIsInstance(regular, self.dict_class)
 
         def get_attr():
             regular.a = 2
@@ -201,20 +211,20 @@ class Tests(unittest.TestCase):
 
     def test_to_dict_with_tuple(self):
         nested = {'a': ({'a': 0}, {2: 0})}
-        prop = Dict(nested)
+        prop = self.dict_class(nested)
         regular = prop.to_dict()
         self.assertDictEqual(regular, prop)
         self.assertDictEqual(regular, nested)
         self.assertIsInstance(regular['a'], tuple)
-        self.assertNotIsInstance(regular['a'][0], Dict)
+        self.assertNotIsInstance(regular['a'][0], self.dict_class)
 
     def test_update(self):
-        old = Dict()
+        old = self.dict_class()
         old.child.a = 'a'
         old.child.b = 'b'
         old.foo = 'c'
 
-        new = Dict()
+        new = self.dict_class()
         new.child.b = 'b2'
         new.child.c = 'c'
         new.foo.bar = True
@@ -227,9 +237,9 @@ class Tests(unittest.TestCase):
         self.assertDictEqual(old, reference)
 
     def test_update_with_lists(self):
-        org = Dict()
+        org = self.dict_class()
         org.a = [1, 2, {'a': 'superman'}]
-        someother = Dict()
+        someother = self.dict_class()
         someother.b = [{'b': 123}]
         org.update(someother)
 
@@ -241,26 +251,26 @@ class Tests(unittest.TestCase):
         self.assertIsInstance(org.b[0], dict)
 
     def test_update_with_kws(self):
-        org = Dict(one=1, two=2)
-        someother = Dict(one=3)
+        org = self.dict_class(one=1, two=2)
+        someother = self.dict_class(one=3)
         someother.update(one=1, two=2)
         self.assertDictEqual(org, someother)
 
     def test_update_with_args_and_kwargs(self):
         expected = {'a': 1, 'b': 2}
-        org = Dict()
+        org = self.dict_class()
         org.update({'a': 3, 'b': 2}, a=1)
         self.assertDictEqual(org, expected)
 
     def test_update_with_multiple_args(self):
-        org = Dict()
         def update():
             org.update({'a': 2}, {'a': 1})
+        org = self.dict_class()
         self.assertRaises(TypeError, update)
 
     def test_hook_in_constructor(self):
-        a_dict = Dict(TEST_DICT)
-        self.assertIsInstance(a_dict['a'], Dict)
+        a_dict = self.dict_class(TEST_DICT)
+        self.assertIsInstance(a_dict['a'], self.dict_class)
 
     def test_copy(self):
         class MyMutableObject(object):
@@ -271,7 +281,7 @@ class Tests(unittest.TestCase):
         foo = MyMutableObject()
         foo.attribute = True
 
-        a = Dict()
+        a = self.dict_class()
         a.child.immutable = 42
         a.child.mutable = foo
 
@@ -287,7 +297,7 @@ class Tests(unittest.TestCase):
 
         # changing child of b should not affect a
         b.child = "new stuff"
-        self.assertTrue(isinstance(a.child, Dict))
+        self.assertTrue(isinstance(a.child, self.dict_class))
 
     def test_deepcopy(self):
         class MyMutableObject(object):
@@ -297,7 +307,7 @@ class Tests(unittest.TestCase):
         foo = MyMutableObject()
         foo.attribute = True
 
-        a = Dict()
+        a = self.dict_class()
         a.child.immutable = 42
         a.child.mutable = foo
 
@@ -313,7 +323,7 @@ class Tests(unittest.TestCase):
 
         # changing child of b should not affect a
         b.child = "new stuff"
-        self.assertTrue(isinstance(a.child, Dict))
+        self.assertTrue(isinstance(a.child, self.dict_class))
 
     def test_deepcopy2(self):
         class MyMutableObject(object):
@@ -323,7 +333,7 @@ class Tests(unittest.TestCase):
         foo = MyMutableObject()
         foo.attribute = True
 
-        a = Dict()
+        a = self.dict_class()
         a.child.immutable = 42
         a.child.mutable = foo
 
@@ -339,34 +349,34 @@ class Tests(unittest.TestCase):
 
         # changing child of b should not affect a
         b.child = "new stuff"
-        self.assertTrue(isinstance(a.child, Dict))
+        self.assertTrue(isinstance(a.child, self.dict_class))
 
     def test_pickle(self):
-        a = Dict(TEST_DICT)
+        a = self.dict_class(TEST_DICT)
         self.assertEqual(a, pickle.loads(pickle.dumps(a)))
 
     def test_add_on_empty_dict(self):
-        d = Dict()
+        d = self.dict_class()
         d.x.y += 1
 
         self.assertEqual(d.x.y, 1)
 
     def test_add_on_non_empty_dict(self):
-        d = Dict()
+        d = self.dict_class()
         d.x.y = 'defined'
 
         with self.assertRaises(TypeError):
             d.x += 1
 
     def test_add_on_non_empty_value(self):
-        d = Dict()
+        d = self.dict_class()
         d.x.y = 1
         d.x.y += 1
 
         self.assertEqual(d.x.y, 2)
 
     def test_add_on_unsupported_type(self):
-        d = Dict()
+        d = self.dict_class()
         d.x.y = 'str'
 
         with self.assertRaises(TypeError):
@@ -376,11 +386,11 @@ class Tests(unittest.TestCase):
         keys = ['a']
         values = [42]
         items = zip(keys, values)
-        d = Dict(items)
+        d = self.dict_class(items)
         self.assertEqual(d.a, 42)
 
     def test_setdefault_simple(self):
-        d = Dict()
+        d = self.dict_class()
         d.setdefault('a', 2)
         self.assertEqual(d.a, 2)
         d.setdefault('a', 3)
@@ -389,14 +399,14 @@ class Tests(unittest.TestCase):
         self.assertEqual(d.c, [2])
 
     def test_setdefault_nested(self):
-        d = Dict()
+        d = self.dict_class()
         d.one.setdefault('two', [])
         self.assertEqual(d.one.two, [])
         d.one.setdefault('three', []).append(3)
         self.assertEqual(d.one.three, [3])
-    
+
     def test_parent_key_item(self):
-        a = Dict()
+        a = self.dict_class()
         try:
             a['keys']['x'] = 1
         except AttributeError as e:
@@ -406,19 +416,31 @@ class Tests(unittest.TestCase):
         except Exception as e:
             self.fail(e)
         self.assertEquals(a, {'keys': {'x': 1}, 1: {'x': 3}})
-    
+
     def test_parent_key_prop(self):
-        a = Dict()
+        a = self.dict_class()
         try:
             a.y.x = 1
         except AttributeError as e:
             self.fail(e)
         self.assertEquals(a, {'y': {'x': 1}})
 
+
+class DictTests(AbstractTestsClass):
+    dict_class = Dict
+
+
+class ChildDictTests(AbstractTestsClass):
+    dict_class = CHILD_CLASS
+
 """
 Allow for these test cases to be run from the command line
 via `python test_addict.py`
 """
 if __name__ == '__main__':
-    all_tests = unittest.TestLoader().loadTestsFromTestCase(Tests)
-    unittest.TextTestRunner(verbosity=2).run(all_tests)
+    test_classes = (DictTests, ChildDictTests)
+    loader = unittest.TestLoader()
+    runner = unittest.TextTestRunner(verbosity=2)
+    for class_ in test_classes:
+        loaded_tests = loader.loadTestsFromTestCase(class_)
+        runner.run(loaded_tests)


### PR DESCRIPTION
`Dict` subclasses' child nodes are now reflect the expected behavior that they're instances of that subclass instead of `Dict`s. Without this change, daughter nodes of subclass instances raise Attribute or other errors. 

Added tests appropriate for these changes. 100% of tests passed.

See https://github.com/mewwts/addict/issues/101