### PR TITLE
Add alias 'Addict' to import Dict

### DIFF
--- a/addict/__init__.py
+++ b/addict/__init__.py
@@ -1,4 +1,5 @@
 from .addict import Dict
+from .addict import Dict as Addict
 
 
 __title__ = 'addict'


### PR DESCRIPTION
Currently, when importing `Dict` from `addict` like this:

```python
from addict import Dict
```

..., where `Dict` will conflict with `Dict` from `typing`.

It would be handy if the library would offer an alternative import name so both `Dict` classes can get imported easily:
```python
from addict import Addict
from typing import Dict
```