### PR TITLE
Update addict.py

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -139,7 +139,7 @@ class Dict(dict):
             self[key] = default
             return default
         
-    def get(self, key, default='salope'):
+    def get(self, key, default=None):
         try:
             return self.__getitem__(key)
         except:


### PR DESCRIPTION
The following patch is an implmentation of two pending pull requests:
- access to nested keys
- dict freezing.

Access to nested keys.
processes dotted keys in get_item and setitem, so that we can write
print( d['path.to.nested.key'] )
print( d.get('path.to.nested.key') )
and d['path.to.nested.key']='some_value'

Dict freezing
the default is to create nested keys as empty dict if we try to access non existing keys
d=Dict()
d.key1.key2='some_value'
print (d.key5) # returns {}
print (d['key5']) # returns {}

with freezing
d=Dict()
d.key1.key2='some_value'
d.freeze()
print (d.key5) # raises keyError
print (d['key5']) # raises KeyError