### PR TITLE
freeze(), unfreeze(), and nested key support

### DIFF
--- a/test_addict.py
+++ b/test_addict.py
@@ -425,6 +425,45 @@ class AbstractTestsClass(object):
             self.fail(e)
         self.assertEquals(a, {'y': {'x': 1}})
 
+    def test_set_two_level_items_dotkey(self):
+        some_dict = {'a': {'b': TEST_VAL}}
+        prop = self.dict_class()
+        prop['a.b'] = TEST_VAL
+        self.assertDictEqual(prop, some_dict)
+
+    def test_set_three_level_items_dotkey(self):
+        prop = self.dict_class()
+        prop['a.b.c'] = TEST_VAL
+        self.assertDictEqual(prop, TEST_DICT)
+
+    def test_freeze_read_non_existing_key(self):
+        prop = self.dict_class()
+        prop['a.b.c'] = TEST_VAL
+        with self.assertRaises(KeyError):
+            prop.freeze().a.b.n
+        with self.assertRaises(KeyError):
+            prop.freeze().a.n.c
+        assert prop.unfreeze().a.n.c=={}
+
+    def test_freeze_two_level_set_non_existing_key(self):
+        prop = self.dict_class()
+        prop['a.b.c'] = TEST_VAL
+        with self.assertRaises(KeyError):
+            prop.freeze()['a.b.d']='fail'
+        with self.assertRaises(KeyError):
+            prop.freeze()['a.d.c']='fail'
+        assert prop.unfreeze().a.b.n=={}
+        assert prop.unfreeze().a.n.c=={}
+
+    def test_get_with_default(self):
+        prop = self.dict_class()
+        prop['a.b.c'] = TEST_VAL
+        assert prop.get('a.b.c','default')== TEST_VAL
+        assert prop.get('a.b.d','default')== 'default'
+        assert prop.get('a.d.c','default')== 'default'
+        # check that prop is not locked
+        assert prop.a.n.c=={}
+
 
 class DictTests(unittest.TestCase, AbstractTestsClass):
     dict_class = Dict


### PR DESCRIPTION
The following patch addresses issues 110 (and closely related 117) and 121
This is my first pull request! be indulgent!

#110 Deep setattr and gettattr when attribute names contain '.'
the patch enables
d=Dict()
var keypath='path.to.nested.key'
d[ keypath ]='test'
print(d [ keypass] )

#121 Is it possible to forbid accessing missing keys?
adict returns an empty dict when trying to access non existing keys
d=Dict()
assert d.a.b.c == {}
the patch introduces d.freeze() and d.unfreeze().
When the dict is frozen, you cannot create new keys (keyError raised) but you can modify existing ones
The patch overrides default get method to 
- get frozen/unfrozen state
- freeze dict
- return d[key] if key exists otherwise default
-restore frozen/unfrozen state

