### PR TITLE
Add Python 3.9's merge operators `|` and `|=` support (#127)

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -118,14 +118,14 @@ class Dict(dict):
         self.update(state)
 
     def __or__(self, other):
-        if not isinstance(other, Dict):
+        if not isinstance(other, (Dict, dict)):
             return NotImplemented
         new = Dict(self)
         new.update(other)
         return new
 
     def __ror__(self, other):
-        if not isinstance(other, Dict):
+        if not isinstance(other, (Dict, dict)):
             return NotImplemented
         new = Dict(other)
         new.update(self)

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -117,6 +117,24 @@ class Dict(dict):
     def __setstate__(self, state):
         self.update(state)
 
+    def __or__(self, other):
+        if not isinstance(other, Dict):
+            return NotImplemented
+        new = Dict(self)
+        new.update(other)
+        return new
+
+    def __ror__(self, other):
+        if not isinstance(other, Dict):
+            return NotImplemented
+        new = Dict(other)
+        new.update(self)
+        return new
+
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
     def setdefault(self, key, default=None):
         if key in self:
             return self[key]

--- a/test_addict.py
+++ b/test_addict.py
@@ -337,6 +337,31 @@ class AbstractTestsClass(object):
         org = org | someother
         self.assertDictEqual(org, correct)
         self.assertIsInstance(org.b[0], dict)
+    
+    def test_ror_operator(self):
+        org = dict()
+        org['a'] = [1, 2, {'a': 'superman'}]
+        someother = self.dict_class()
+        someother.b = [{'b': 123}]
+        org = org | someother
+
+        correct = {'a': [1, 2, {'a': 'superman'}],
+                   'b': [{'b': 123}]}
+
+        org = org | someother
+        self.assertDictEqual(org, correct)
+        self.assertIsInstance(org, Dict)
+        self.assertIsInstance(org.b[0], dict)
+  
+    def test_or_operator_type_error(self):
+        old = self.dict_class()
+        with self.assertRaises(TypeError):
+            old | 'test'
+
+    def test_ror_operator_type_error(self):
+        old = self.dict_class()
+        with self.assertRaises(TypeError):
+            'test' | old
 
     def test_hook_in_constructor(self):
         a_dict = self.dict_class(TEST_DICT)

--- a/test_addict.py
+++ b/test_addict.py
@@ -267,6 +267,76 @@ class AbstractTestsClass(object):
             org.update({'a': 2}, {'a': 1})
         org = self.dict_class()
         self.assertRaises(TypeError, update)
+        
+    def test_ior_operator(self):
+        old = self.dict_class()
+        old.child.a = 'a'
+        old.child.b = 'b'
+        old.foo = 'c'
+
+        new = self.dict_class()
+        new.child.b = 'b2'
+        new.child.c = 'c'
+        new.foo.bar = True
+
+        old |= new
+
+        reference = {'foo': {'bar': True},
+                     'child': {'a': 'a', 'c': 'c', 'b': 'b2'}}
+
+        self.assertDictEqual(old, reference)
+
+    def test_ior_operator_with_lists(self):
+        org = self.dict_class()
+        org.a = [1, 2, {'a': 'superman'}]
+        someother = self.dict_class()
+        someother.b = [{'b': 123}]
+        org |= someother
+
+        correct = {'a': [1, 2, {'a': 'superman'}],
+                   'b': [{'b': 123}]}
+
+        org |= someother
+        self.assertDictEqual(org, correct)
+        self.assertIsInstance(org.b[0], dict)
+
+    def test_ior_operator_with_dict(self):
+        org = self.dict_class(one=1, two=2)
+        someother = self.dict_class(one=3)
+        someother |= dict(one=1, two=2)
+        self.assertDictEqual(org, someother)
+
+    def test_or_operator(self):
+        old = self.dict_class()
+        old.child.a = 'a'
+        old.child.b = 'b'
+        old.foo = 'c'
+
+        new = self.dict_class()
+        new.child.b = 'b2'
+        new.child.c = 'c'
+        new.foo.bar = True
+
+        old = old | new
+
+        reference = {'foo': {'bar': True},
+                     'child': {'a': 'a', 'c': 'c', 'b': 'b2'}}
+
+        self.assertDictEqual(old, reference)
+
+    def test_or_operator_with_lists(self):
+        org = self.dict_class()
+        org.a = [1, 2, {'a': 'superman'}]
+        someother = self.dict_class()
+        someother.b = [{'b': 123}]
+        org = org | someother
+
+        correct = {'a': [1, 2, {'a': 'superman'}],
+                   'b': [{'b': 123}]}
+
+        org = org | someother
+        self.assertDictEqual(org, correct)
+        self.assertIsInstance(org.b[0], dict)
 
     def test_hook_in_constructor(self):
         a_dict = self.dict_class(TEST_DICT)
@@ -415,7 +485,7 @@ class AbstractTestsClass(object):
             a[1].x = 3
         except Exception as e:
             self.fail(e)
-        self.assertEquals(a, {'keys': {'x': 1}, 1: {'x': 3}})
+        self.assertEqual(a, {'keys': {'x': 1}, 1: {'x': 3}})
 
     def test_parent_key_prop(self):
         a = self.dict_class()
@@ -423,7 +493,7 @@ class AbstractTestsClass(object):
             a.y.x = 1
         except AttributeError as e:
             self.fail(e)
-        self.assertEquals(a, {'y': {'x': 1}})
+        self.assertEqual(a, {'y': {'x': 1}})
 
 
 class DictTests(unittest.TestCase, AbstractTestsClass):


### PR DESCRIPTION
Add Python 3.9's merge operators `|` and `|=` support (#127 ) with passing tests.

The implementation simply uses the snippet provided in the PEP https://www.python.org/dev/peps/pep-0584/#reference-implementation

Also fixes the deprecated assertEquals of the unit tests