### PR TITLE
Intro'd freeze/unfreeze.

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -30,6 +30,10 @@ class Dict(dict):
             self[name] = value
 
     def __setitem__(self, name, value):
+        isFrozen = (hasattr(self, '__frozen') and
+                    object.__getattribute__(self, '__frozen'))
+        if isFrozen and name not in super(Dict, self).keys():
+                raise KeyError(name)
         super(Dict, self).__setitem__(name, value)
         try:
             p = object.__getattribute__(self, '__parent')

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -6,6 +6,7 @@ class Dict(dict):
     def __init__(__self, *args, **kwargs):
         object.__setattr__(__self, '__parent', kwargs.pop('__parent', None))
         object.__setattr__(__self, '__key', kwargs.pop('__key', None))
+        object.__setattr__(__self, '__frozen', False)
         for arg in args:
             if not arg:
                 continue
@@ -62,6 +63,8 @@ class Dict(dict):
         return self.__getitem__(item)
 
     def __missing__(self, name):
+        if object.__getattribute__(self, '__frozen'):
+            raise KeyError(name)
         return self.__class__(__parent=self, __key=name)
 
     def __delattr__(self, name):
@@ -141,3 +144,12 @@ class Dict(dict):
         else:
             self[key] = default
             return default
+
+    def freeze(self, shouldFreeze=True):
+        object.__setattr__(self, '__frozen', shouldFreeze)
+        for key, val in self.items():
+            if isinstance(val, Dict):
+                val.freeze(shouldFreeze)
+
+    def unfreeze(self):
+        self.freeze(False)

--- a/test_addict.py
+++ b/test_addict.py
@@ -559,22 +559,18 @@ class AbstractTestsClass(object):
         d.inner.unfreeze()
         self.assertEqual(d.inner.missing, {})
 
-    def test_top_freeze_allows_key_addition(self):
-        "Test that d.freeze() allows setting d.missing (but not d.missing.foo)"
-        d = self.dict_class()
+    def test_top_freeze_disallows_new_key_addition(self):
+        "Test that d.freeze() disallows adding new keys in d."
+        d = self.dict_class({"oldKey": None})
         d.freeze()
+        d.oldKey = TEST_VAL         # Can set pre-existing key.
+        self.assertEqual(d.oldKey, TEST_VAL)
         with self.assertRaises(KeyError):
-            d.keyX
-        with self.assertRaises(KeyError):
-            d.keyY
-        d.keyX = TEST_VAL
-        self.assertEqual(d.keyX, TEST_VAL)
-        with self.assertRaises(KeyError):
-            d.keyY.insideY = TEST_VAL
+            d.newKey = TEST_VAL     # But can't add a new key.
+        self.assertNotIn("newKey", d)
         d.unfreeze()
-        d.keyY.insideY = TEST_VAL
-        self.assertEqual(d.keyY.insideY, TEST_VAL)
-
+        d.newKey = TEST_VAL
+        self.assertEqual(d.newKey, TEST_VAL)
 
 class DictTests(unittest.TestCase, AbstractTestsClass):
     dict_class = Dict


### PR DESCRIPTION

Based on my reading of #121, it's clear that the need for `.freeze()` arises from the desire for `KeyError`s, so that typos can be caught quickly. Keeping this in mind, I've tried to make minimal additions.

### The Basics
When an `addict.Dict` is frozen, accessing a missing key will raise a `KeyError`. This is true for nested `addict.Dict` instances too.

### Allowing Key Addition
In some sense, a plain Python `dict` is already frozen, as it always raises `KeyError`s. Note that plain `dict`s allow the addition of new keys. Thus, it should make sense to allow the addition to new keys to frozen addicts, but *only* at the top level. That is:
-  `frozenDicty.newKey = 1` should work as expected, but
- `frozenDicty.missingKey.newKey = 1` should raise a `KeyError`.

### Unfreezing is a Shorthand
As `.freeze()` and `.unfreeze()` are very similar, differing only in a boolean flag, it made sense to implement `.unfreeze()` as a shorthand for `.freeze(False)`. Specifically:
- `.freeze()` is equivalent to `.freeze(True)`, and
- `.unfreeze()` is a shorthand for `.freeze(False)`.

### No Frozen Initialization
Thought about adding a `__frozen` param to `__init__()`, but decided against it. If required, such functionality can easily be added later. And while a such a parameter is mentioned in #121, in favoring explicit vs implicit, it may be best to require the user to explicitly call `.freeze()`.

### No Return Value
Currently, `.freeze()` (including `.unfreeze()`) returns `None`, not an `addict.Dict`. This is similar to Python's built-in `dict.update()`. While #121 suggests making `.freeze()` return a frozen `addict.Dict`, retaining parity with `dict.update()` may be desirable.