### PR TITLE
docs: fix simple typo, overriden -> overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ just like a regular `dict`. There are no restrictions (other than what a regular
 ### Default values
 For keys that are not in the dictionary, addict behaves like ```defaultdict(Dict)```, so missing keys return an empty ```Dict```
 rather than raising ```KeyError```.
-If this behaviour is not desired, it can be overriden using
+If this behaviour is not desired, it can be overridden using
 ```Python
 >>> class DictNoDefault(Dict):
 >>>     def __missing__(self, key):


### PR DESCRIPTION
There is a small typo in README.md.

Should read `overridden` rather than `overriden`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md