### PR TITLE
fix copy and pickle so they work with freezing

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -119,10 +119,16 @@ class Dict(dict):
         return tuple(self.items())
 
     def __getstate__(self):
-        return self
+        state = self.to_dict()
+        isFrozen = (hasattr(self, '__frozen') and
+                    object.__getattribute__(self, '__frozen'))
+        state['__addict__frozen__'] = isFrozen
+        return state
 
     def __setstate__(self, state):
+        shouldFreeze = state.pop('__addict__frozen__', False)
         self.update(state)
+        self.freeze(shouldFreeze)
 
     def __or__(self, other):
         if not isinstance(other, (Dict, dict)):


### PR DESCRIPTION
This PR makes it so frozen Dict's can be copied and pickled.  Addresses #136 

```
>>> from addict import Dict
>>> a = Dict().copy()
>>> a.foo.bar
{}
>>> b = Dict(aaa=1, bbb=2)
>>> b.freeze()
>>> b.aaa == 1
True
>>> b.ccc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/addict/addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File "/addict/addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'ccc'
>>> c = b.copy()
>>> c.ddd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/addict/addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File "/addict/addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'ddd'
>>> 

```