### PR TITLE
implement json converter and representation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ docs/_build/
 # PyBuilder
 target/
 
-
-#OSX Files
+# OSX Files
 .DS_Store
+
+# IDE caches
+.idea/
+.vscode/
+

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -165,10 +165,12 @@ class Dict(dict):
         for key, value in self.items():
             if isinstance(value, type(self)):
                 base[key] = value.json()
+            elif isinstance(value, dict):
+                base[key] = Dict(value).json()
             elif isinstance(value, (list, tuple)):
                 base[key] = list(
                     (Dict(item).json() if callable(item.json) else item.json)
-                    if isinstance(item, type(self)) or hasattr(item, "json")
+                    if isinstance(item, (type(self), dict)) or hasattr(item, "json")
                     else item
                     if isinstance(item, (int, float, bool, str, type(None)))
                     else str(item)

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -161,15 +161,13 @@ class Dict(dict):
         self.freeze(False)
 
     def json(self, force=True):
-        base = self.to_dict()
+        base = {}
         for key, value in self.items():
-            if isinstance(value, type(self)):
-                base[key] = value.json()
-            elif isinstance(value, dict):
+            if isinstance(value, (type(self), dict)):
                 base[key] = Dict(value).json()
             elif isinstance(value, (list, tuple)):
                 base[key] = list(
-                    (Dict(item).json() if callable(item.json) else item.json)
+                    (Dict(item).json() if callable(item.json) else Dict(item).json)
                     if isinstance(item, (type(self), dict)) or hasattr(item, "json")
                     else item
                     if isinstance(item, (int, float, bool, str, type(None)))

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -160,7 +160,7 @@ class Dict(dict):
     def unfreeze(self):
         self.freeze(False)
 
-    def json(self):
+    def json(self, force=True):
         base = self.to_dict()
         for key, value in self.items():
             if isinstance(value, type(self)):
@@ -173,22 +173,23 @@ class Dict(dict):
                     if isinstance(item, (type(self), dict)) or hasattr(item, "json")
                     else item
                     if isinstance(item, (int, float, bool, str, type(None)))
-                    else str(item)
+                    else str(item) if force else item
                     for item in value)
             elif isinstance(value, (int, float, bool, str, type(None))):
                 base[key] = value
             elif hasattr(value, "json"):
                 base[key] = value.json() if callable(value.json) else value.json
             else:
-                base[key] = str(value)
+                base[key] = str(value) if force else value
         return base
 
     def __repr__(self):
         if self.__json__:
             cls = type(self)
             try:
-                repr_ = json.dumps(self.json(), indent=2, ensure_ascii=False)
+                repr_ = json.dumps(self.json(force=False),
+                                   indent=2, ensure_ascii=False)
             except Exception:  # noqa
-                repr_ = dict.__repr__(self)
+                return dict.__repr__(self)
             return "{0}.{1}\n{2}".format(cls.__module__, cls.__name__, repr_)
         return dict.__repr__(self)


### PR DESCRIPTION
Hi, 
First, I would like to say thanks for this amazing library! Very useful. 

While developing on some of my projects, I came across a few times into situations where the convenience offered by this library was taken away because it was tedious to ensure JSON serializable items deeply nested in the definitions. 

To resolve this, I came across the approach presented in this PR. I would like to contribute it.
There are 2 additions: 

- method `json` that specifically ask the `Dict` (or its derived class) to call JSON conversion.
  This is a bit similar to `to_dict` method, but specifically looks for `json` method or properly in nested items. 
  This method name is often employed, for example, in `requests` library items, `pyramid`, `flask` and many others.
  It also enforces `str` conversion of un-serializable items, such that the generated content is valid for `json.dumps` use.
  Any sub-class not directly JSON serializable only needs to implement `json` and will automatically benefit from the resolution.

- method `__repr__` combined with `__json__` option. 
  When activated, the representation of the `Dict` will be a "pretty print" representation (as JSON) of the contents. 
  The module and name of the class is also displayed before the JSON representation to indicate it was a `Dict` or derived class. 

I'm also open to further improvements if needed. Feedback welcomed. 


