### PR TITLE
Fix getattr compatibility issues and add getattr tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If this behaviour is not desired, it can be overridden using
 ```Python
 >>> class DictNoDefault(Dict):
 >>>     def __missing__(self, key):
->>>         raise KeyError(key)
+>>>         raise AttributeError(key)
 ```
 but beware that you will then lose the shorthand assignment functionality (```addicted.a.b.c.d.e = 2```).
 

--- a/addict/addict.py
+++ b/addict/addict.py
@@ -68,7 +68,7 @@ class Dict(dict):
 
     def __missing__(self, name):
         if object.__getattribute__(self, '__frozen'):
-            raise KeyError(name)
+            raise AttributeError(name)
         return self.__class__(__parent=self, __key=name)
 
     def __delattr__(self, name):


### PR DESCRIPTION
The library gives incorrect behavior with `getattr`:
```Python
>>> from addict import Dict
>>> body = Dict(a=1)
>>> body.freeze()
>>> getattr(body, 'missing', 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'missing'
```
The expected result should be 2.

This pull request fixes the issue, and adds related `getattr` tests.