### PR TITLE
Fix the error type for missing attributes and getattr compatibility issues

### DIFF
--- a/addict/addict.py
+++ b/addict/addict.py
@@ -27,7 +27,13 @@ class Dict(dict):
             raise AttributeError("'Dict' object attribute "
                                  "'{0}' is read-only".format(name))
         else:
-            self[name] = value
+            try:
+                self[name] = value
+            except KeyError:
+                self_type = type(self).__name__
+                raise AttributeError(
+                    "'{}' object has no attribute '{}'".format(
+                        self_type, name))
 
     def __setitem__(self, name, value):
         isFrozen = (hasattr(self, '__frozen') and
@@ -64,7 +70,12 @@ class Dict(dict):
         return item
 
     def __getattr__(self, item):
-        return self.__getitem__(item)
+        try:
+            return self.__getitem__(item)
+        except KeyError:
+            self_type = type(self).__name__
+            raise AttributeError("'{}' object has no attribute '{}'".format(
+                self_type, item))
 
     def __missing__(self, name):
         if object.__getattribute__(self, '__frozen'):


### PR DESCRIPTION
The library gives incorrect behavior with `getattr`:
```Python
>>> from addict import Dict
>>> body = Dict(a=1)
>>> body.freeze()
>>> getattr(body, 'missing', 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'missing'
```
The expected result should be 2 (when the attribute does not exist, the default value 2 should be returned).

The error type for missing attributes is not consistent with Python standards:
```Python
>>> body = Dict()
>>> body.freeze()
>>> body.missing_key
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'missing_key'
```
The correct error type should be `AttributeError`.

These issues are all from the same root cause: when the `Dict` object is frozen and a missing attribute is accessed, `AttributeError` should be raised (instead of `KeyError`). `getattr` uses `AttributeError` to detect if the default value should be supplied. When `KeyError` is raised instead, `getattr` will not supply the default value.

This pull request fixes these issues and adds related tests.

In more detail, the changes are:

## Error for `body.missing_key`
Before:
```Python
>>> body = Dict()
>>> body.freeze()
>>> body.missing_key
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'missing_key'
```
However, the error type should be `AttributeError` instead. This pull request fixes this issue by catching it and throwing the correct error type:

```Python
>>> body = Dict()
>>> body.freeze()
>>> body.missing_key
Traceback (most recent call last):
  File ".../addict/addict/addict.py", line 74, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict/addict.py", line 82, in __missing__
    raise KeyError(name)
KeyError: 'missing_key'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict/addict.py", line 77, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'Dict' object has no attribute 'missing_key'
```

## Error for `body["missing_key"]`
The error type for missing key access is still the same as before (KeyError) as this is the correct behavior:
```Python
>>> body["missing_key"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict/addict.py", line 82, in __missing__
    raise KeyError(name)
KeyError: 'missing_key'
```

## `getattr`
Before:
```Python
>>> body = Dict(a=1)
>>> body.freeze()
>>> getattr(body, 'missing', 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../addict/addict.py", line 67, in __getattr__
    return self.__getitem__(item)
  File ".../addict/addict.py", line 71, in __missing__
    raise KeyError(name)
KeyError: 'missing'
```
The expected result should be 2. This pull request fixes the issue:
```Python
>>> body = Dict(a=1)
>>> body.freeze()
>>> getattr(body, 'missing', 2)
2
```

----
> Note: This pull request is to replace #145 with a better implementation: #145 throws AttributeError for missing key access (body['missing_key']), but this pull request throws KeyError to be consistent with Python standards.